### PR TITLE
issue#37 멤버 페이지 UI 구현

### DIFF
--- a/src/app/(main)/_components/header/navigation/Navigation.tsx
+++ b/src/app/(main)/_components/header/navigation/Navigation.tsx
@@ -26,6 +26,10 @@ export const navigationLinks = [
     href: '/notice',
   },
   {
+    name: '멤버',
+    href: '/member',
+  },
+  {
     name: '모집',
     href: '/recruit',
   },

--- a/src/app/(main)/member/_components/index.ts
+++ b/src/app/(main)/member/_components/index.ts
@@ -1,0 +1,1 @@
+export * from './member-card'

--- a/src/app/(main)/member/_components/member-card/FlipCard.tsx
+++ b/src/app/(main)/member/_components/member-card/FlipCard.tsx
@@ -1,0 +1,28 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui'
+
+interface FlipCardProps {
+  userImageUrl?: string
+  userDetail?: string
+}
+
+export const FlipCard = ({ userImageUrl, userDetail }: FlipCardProps) => {
+  return (
+    <div className="h-auto w-full transition-all duration-500 [transform-style:preserve-3d] [transform:perspective(800px)] hover:cursor-pointer hover:[transform:rotateY(180deg)]">
+      <Avatar className="aspect-square h-auto w-full rounded-md object-cover [backface-visibility:hidden]">
+        <AvatarImage src={userImageUrl} />
+        <AvatarFallback className="aspect-square w-full rounded-md px-3 text-sm text-primary/30">
+          프로필 사진이 없습니다
+        </AvatarFallback>
+      </Avatar>
+      <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center rounded-md bg-accent px-3 [backface-visibility:hidden] [transform:rotateY(180deg)]">
+        {userDetail ? (
+          <div className="text-center text-sm text-primary/80">
+            {userDetail}
+          </div>
+        ) : (
+          <div className="text-sm text-primary/30">한 줄 소개가 없습니다</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(main)/member/_components/member-card/MemberCard.tsx
+++ b/src/app/(main)/member/_components/member-card/MemberCard.tsx
@@ -1,0 +1,87 @@
+import { GitHubLogoIcon, InstagramLogoIcon } from '@radix-ui/react-icons'
+
+import { IconButton } from '@/components/common'
+import { Avatar, AvatarFallback, AvatarImage, Card } from '@/components/ui'
+
+interface MemberCardProps {
+  userName: string
+  userImageUrl?: string
+  userDetail?: string
+  githubId?: string
+  instagramId?: string
+}
+
+export const MemberCard = ({
+  userName,
+  userImageUrl,
+  userDetail,
+  githubId,
+  instagramId,
+}: MemberCardProps) => {
+  const onClickGithubIcon = () => {
+    if (!githubId) return
+
+    window.open(
+      `https://github.com/${githubId}`,
+      '_blank',
+      'noopener,noreferrer',
+    )
+  }
+
+  const onClickInstagramIcon = () => {
+    if (!instagramId) return
+
+    window.open(
+      `https://www.instagram.com/${instagramId}`,
+      '_blank',
+      'noopener,noreferrer',
+    )
+  }
+
+  return (
+    <Card className="flex h-auto w-52 flex-col items-center justify-evenly p-4">
+      <div className="h-auto w-full transition-all duration-500 [transform-style:preserve-3d] [transform:perspective(800px)] hover:cursor-pointer hover:[transform:rotateY(180deg)]">
+        <Avatar className="aspect-4/3 h-auto w-full rounded-md [backface-visibility:hidden]">
+          <AvatarImage src={userImageUrl} />
+          <AvatarFallback className="aspect-4/3 w-full rounded-md text-border">
+            프로필 사진이 없습니다
+          </AvatarFallback>
+
+          <div className="absolute bottom-0 right-0 h-6 w-6 rounded-tl-sm bg-white">
+            <div className="absolute h-0 w-0 rounded-sm border-r-[26px] border-t-[26px] border-r-transparent border-t-slate-200"></div>
+          </div>
+        </Avatar>
+
+        <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center rounded-sm bg-accent px-3 [backface-visibility:hidden] [transform:rotateY(180deg)]">
+          {userDetail ? (
+            <div className="text-center text-sm text-primary/80">
+              {userDetail}
+            </div>
+          ) : (
+            <div className="text-border">한 줄 소개가 없습니다</div>
+          )}
+          <div className="absolute bottom-0 left-0 h-6 w-6 rounded-tl-sm bg-white">
+            <div className="absolute h-0 w-0 rounded-sm border-l-[26px] border-t-[26px] border-l-transparent border-t-accent"></div>
+          </div>
+        </div>
+      </div>
+      <div className="flex w-full items-center justify-end pt-2">
+        <div className="w-full pl-1 text-lg font-semibold">{userName}</div>
+        <div className="flex gap-2">
+          {githubId && (
+            <IconButton
+              icon={<GitHubLogoIcon className="h-auto w-5" />}
+              onClick={onClickGithubIcon}
+            />
+          )}
+          {instagramId && (
+            <IconButton
+              icon={<InstagramLogoIcon className="h-auto w-5" />}
+              onClick={onClickInstagramIcon}
+            />
+          )}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/app/(main)/member/_components/member-card/MemberCard.tsx
+++ b/src/app/(main)/member/_components/member-card/MemberCard.tsx
@@ -39,17 +39,13 @@ export const MemberCard = ({
   }
 
   return (
-    <Card className="flex h-auto w-52 flex-col items-center justify-evenly p-4">
+    <Card className="flex h-auto w-40 flex-col items-center justify-evenly p-4 md:w-52">
       <div className="h-auto w-full transition-all duration-500 [transform-style:preserve-3d] [transform:perspective(800px)] hover:cursor-pointer hover:[transform:rotateY(180deg)]">
-        <Avatar className="aspect-4/3 h-auto w-full rounded-md [backface-visibility:hidden]">
+        <Avatar className="aspect-square h-auto w-full rounded-md object-cover [backface-visibility:hidden]">
           <AvatarImage src={userImageUrl} />
-          <AvatarFallback className="aspect-4/3 w-full rounded-md text-border">
+          <AvatarFallback className="aspect-square w-full rounded-md px-3 text-sm text-primary/30">
             프로필 사진이 없습니다
           </AvatarFallback>
-
-          <div className="absolute bottom-0 right-0 h-6 w-6 rounded-tl-sm bg-white">
-            <div className="absolute h-0 w-0 rounded-sm border-r-[26px] border-t-[26px] border-r-transparent border-t-slate-200"></div>
-          </div>
         </Avatar>
 
         <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center rounded-sm bg-accent px-3 [backface-visibility:hidden] [transform:rotateY(180deg)]">
@@ -58,11 +54,8 @@ export const MemberCard = ({
               {userDetail}
             </div>
           ) : (
-            <div className="text-border">한 줄 소개가 없습니다</div>
+            <div className="text-sm text-primary/30">한 줄 소개가 없습니다</div>
           )}
-          <div className="absolute bottom-0 left-0 h-6 w-6 rounded-tl-sm bg-white">
-            <div className="absolute h-0 w-0 rounded-sm border-l-[26px] border-t-[26px] border-l-transparent border-t-accent"></div>
-          </div>
         </div>
       </div>
       <div className="flex w-full items-center justify-end pt-2">

--- a/src/app/(main)/member/_components/member-card/MemberCard.tsx
+++ b/src/app/(main)/member/_components/member-card/MemberCard.tsx
@@ -1,7 +1,9 @@
 import { GitHubLogoIcon, InstagramLogoIcon } from '@radix-ui/react-icons'
 
 import { IconButton } from '@/components/common'
-import { Avatar, AvatarFallback, AvatarImage, Card } from '@/components/ui'
+import { Card } from '@/components/ui'
+
+import { FlipCard } from './FlipCard'
 
 interface MemberCardProps {
   userName: string
@@ -40,24 +42,7 @@ export const MemberCard = ({
 
   return (
     <Card className="flex h-auto w-40 flex-col items-center justify-evenly p-4 md:w-52">
-      <div className="h-auto w-full transition-all duration-500 [transform-style:preserve-3d] [transform:perspective(800px)] hover:cursor-pointer hover:[transform:rotateY(180deg)]">
-        <Avatar className="aspect-square h-auto w-full rounded-md object-cover [backface-visibility:hidden]">
-          <AvatarImage src={userImageUrl} />
-          <AvatarFallback className="aspect-square w-full rounded-md px-3 text-sm text-primary/30">
-            프로필 사진이 없습니다
-          </AvatarFallback>
-        </Avatar>
-
-        <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center rounded-sm bg-accent px-3 [backface-visibility:hidden] [transform:rotateY(180deg)]">
-          {userDetail ? (
-            <div className="text-center text-sm text-primary/80">
-              {userDetail}
-            </div>
-          ) : (
-            <div className="text-sm text-primary/30">한 줄 소개가 없습니다</div>
-          )}
-        </div>
-      </div>
+      <FlipCard userImageUrl={userImageUrl} userDetail={userDetail} />
       <div className="flex w-full items-center justify-end pt-2">
         <div className="w-full pl-1 text-lg font-semibold">{userName}</div>
         <div className="flex gap-2">

--- a/src/app/(main)/member/_components/member-card/index.ts
+++ b/src/app/(main)/member/_components/member-card/index.ts
@@ -1,0 +1,1 @@
+export { MemberCard } from './MemberCard'

--- a/src/app/(main)/member/page.tsx
+++ b/src/app/(main)/member/page.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { MemberCard } from './_components'
+
+export default function MemberPage() {
+  return (
+    <main className="flex h-full w-full flex-col pl-10 pt-10">
+      <MemberCard
+        userName={memberMockData.userName}
+        userImageUrl={memberMockData.userImageUrl}
+        userDetail={memberMockData.userDetail}
+        githubId={memberMockData.githubId}
+        instagramId={memberMockData.instagramId}
+      />
+    </main>
+  )
+}
+
+const memberMockData = {
+  userName: '김아진',
+  userImageUrl: 'https://picsum.photos/200',
+  userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
+  githubId: 'ppochaco',
+  instagramId: 'a_jin34',
+}

--- a/src/app/(main)/member/page.tsx
+++ b/src/app/(main)/member/page.tsx
@@ -4,22 +4,92 @@ import { MemberCard } from './_components'
 
 export default function MemberPage() {
   return (
-    <main className="flex h-full w-full flex-col pl-10 pt-10">
-      <MemberCard
-        userName={memberMockData.userName}
-        userImageUrl={memberMockData.userImageUrl}
-        userDetail={memberMockData.userDetail}
-        githubId={memberMockData.githubId}
-        instagramId={memberMockData.instagramId}
-      />
+    <main className="flex h-full w-full flex-col items-center py-10">
+      <div className="text-xl font-semibold">2024-2 멤버</div>
+      <div className="text-md text-primary/60">
+        해달과 123명의 부원들이 함께 하고 있어요
+      </div>
+      <div className="grid w-full max-w-[400px] grid-cols-2 place-items-center gap-6 pt-6 sm:max-w-[520px] sm:grid-cols-3 md:max-w-[680px] lg:max-w-[920px] lg:grid-cols-4">
+        {memberMockData.map((user) => {
+          return (
+            <MemberCard
+              key={user.userId}
+              userName={user.userName}
+              userImageUrl={user.userImageUrl}
+              userDetail={user.userDetail}
+              githubId={user.githubId}
+              instagramId={user.instagramId}
+            />
+          )
+        })}
+      </div>
     </main>
   )
 }
 
-const memberMockData = {
-  userName: '김아진',
-  userImageUrl: 'https://picsum.photos/200',
-  userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
-  githubId: 'ppochaco',
-  instagramId: 'a_jin34',
-}
+const memberMockData = [
+  {
+    userId: 0,
+    userName: '김아진',
+    userImageUrl: 'https://picsum.photos/200',
+    userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
+    githubId: 'ppochaco',
+    instagramId: 'a_jin34',
+  },
+  {
+    userId: 1,
+    userName: '조대성',
+    userImageUrl: '',
+    userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
+    githubId: '',
+    instagramId: 'a_jin34',
+  },
+  {
+    userId: 2,
+    userName: '김민주',
+    userImageUrl: 'https://picsum.photos/200',
+    userDetail: '',
+    githubId: 'ppochaco',
+    instagramId: '',
+  },
+  {
+    userId: 3,
+    userName: '김강민',
+    userImageUrl: '',
+    userDetail: '',
+    githubId: '',
+    instagramId: '',
+  },
+  {
+    userId: 4,
+    userName: '김아진',
+    userImageUrl: 'https://picsum.photos/200',
+    userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
+    githubId: 'ppochaco',
+    instagramId: 'a_jin34',
+  },
+  {
+    userId: 5,
+    userName: '조대성',
+    userImageUrl: '',
+    userDetail: '일이삼사오육칠팔구십일이삼사오육칠팔구십',
+    githubId: '',
+    instagramId: 'a_jin34',
+  },
+  {
+    userId: 6,
+    userName: '김민주',
+    userImageUrl: 'https://picsum.photos/200',
+    userDetail: '',
+    githubId: 'ppochaco',
+    instagramId: '',
+  },
+  {
+    userId: 7,
+    userName: '김강민',
+    userImageUrl: '',
+    userDetail: '',
+    githubId: '',
+    instagramId: '',
+  },
+]

--- a/src/app/(main)/member/page.tsx
+++ b/src/app/(main)/member/page.tsx
@@ -9,7 +9,7 @@ export default function MemberPage() {
       <div className="text-md text-primary/60">
         해달과 123명의 부원들이 함께 하고 있어요
       </div>
-      <div className="grid w-full max-w-[400px] grid-cols-2 place-items-center gap-6 pt-6 sm:max-w-[520px] sm:grid-cols-3 md:max-w-[680px] lg:max-w-[920px] lg:grid-cols-4">
+      <div className="grid w-full max-w-[320px] grid-cols-2 place-items-center gap-6 pt-6 sm:max-w-[520px] sm:grid-cols-3 md:max-w-[680px] lg:max-w-[920px] lg:grid-cols-4">
         {memberMockData.map((user) => {
           return (
             <MemberCard

--- a/src/app/(main)/member/page.tsx
+++ b/src/app/(main)/member/page.tsx
@@ -7,7 +7,7 @@ export default function MemberPage() {
     <main className="flex h-full w-full flex-col items-center py-10">
       <div className="text-xl font-semibold">2024-2 멤버</div>
       <div className="text-md text-primary/60">
-        해달과 123명의 부원들이 함께 하고 있어요
+        해달과 {memberMockData.length}명의 부원들이 함께 하고 있어요
       </div>
       <div className="grid w-full max-w-[320px] grid-cols-2 place-items-center gap-6 pt-6 sm:max-w-[520px] sm:grid-cols-3 md:max-w-[680px] lg:max-w-[920px] lg:grid-cols-4">
         {memberMockData.map((user) => {

--- a/src/components/common/IconButton.tsx
+++ b/src/components/common/IconButton.tsx
@@ -1,0 +1,20 @@
+import { ReactElement } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface IconButtonProps {
+  icon: ReactElement
+  onClick?: () => void
+  className?: string
+}
+
+export const IconButton = ({ icon, onClick, className }: IconButtonProps) => {
+  return (
+    <div
+      onClick={onClick}
+      className={cn('h-auto w-fit cursor-pointer hover:opacity-80', className)}
+    >
+      {icon}
+    </div>
+  )
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -3,6 +3,7 @@ export { Spinner } from './Spinner'
 export { Content } from './Content'
 export { PaginationButtons } from './PaginationButtons'
 export { default as ErrorHandlingWrapper } from './ErrorHandlingWrapper'
+export { IconButton } from './IconButton'
 
 export * from './PageBreadcrumb'
 export * from './error-boundary'

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,13 +1,14 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import * as LabelPrimitive from '@radix-ui/react-label'
+import { type VariantProps, cva } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 )
 
 const Label = React.forwardRef<

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -75,6 +75,9 @@ const config = {
       screens: {
         xs: '340px',
       },
+      aspectRatio: {
+        '4/3': '4 / 3',
+      },
     },
   },
   plugins: [require('tailwindcss-animate'), require('tailwind-scrollbar-hide')],


### PR DESCRIPTION
### 📝 상세 내용

- 사용되는 데이터가 변경될 가능성있어 간단하게 UI 구성했습니다.
- grid 개수를 반응형(sm~lg)으로 설정합니다
- 프로필 이미지, 한 줄 소개, 깃허브 아이디, 인스타 아이디는 optional로 처리했습니다

- FlipCard: 프로필 이미지를 hover하면 한 줄 소개를 보여줍니다
- 깃허브, 인스타 아이콘: click하면 해당 사이트의 프로필로 이동됩니다

### 공통 컴포넌트 IconButton

- 아이콘을 hover했을 때 공통된 css를 적용합니다
- radix icon을 icon props로 전달해서 사용하면 됩니다

### #️⃣ 이슈 번호
- close #37 


### 🔗 참고 자료



### 📷 스크린샷(선택)

<img width="1552" alt="스크린샷 2024-12-14 오후 11 39 09" src="https://github.com/user-attachments/assets/29fdf87d-e079-4697-98db-2470a2aac4bb" />

