### PR TITLE
issue#57 Footer 모바일 뷰 디자인 수정 

### DIFF
--- a/src/app/(main)/_components/footer/ChannelIcons.tsx
+++ b/src/app/(main)/_components/footer/ChannelIcons.tsx
@@ -8,7 +8,7 @@ import {
 import { IconProps } from '@radix-ui/react-icons/dist/types'
 import Link from 'next/link'
 
-type Channels = {
+type Channel = {
   id: number
   name: string
   href: string
@@ -27,7 +27,7 @@ export const ChannelIcons = () => {
   )
 }
 
-const channels: Channels[] = [
+const channels: Channel[] = [
   {
     id: 0,
     name: 'HAEDAL Email',

--- a/src/app/(main)/_components/footer/ChannelIcons.tsx
+++ b/src/app/(main)/_components/footer/ChannelIcons.tsx
@@ -8,42 +8,42 @@ import {
 import { IconProps } from '@radix-ui/react-icons/dist/types'
 import Link from 'next/link'
 
-type LinkIconData = {
+type Channels = {
   id: number
+  name: string
   href: string
   icon: ComponentType<IconProps>
-  alt: string
 }
 
-export const LinkIcon = () => {
+export const ChannelIcons = () => {
   return (
     <div className="bottom-8 right-12 flex gap-4 sm:absolute">
-      {linkIconData.map((linkIcon) => (
-        <Link href={linkIcon.href} key={linkIcon.id}>
-          <linkIcon.icon className="h-6 w-6" />
+      {channels.map((channel) => (
+        <Link href={channel.href} key={channel.id}>
+          <channel.icon className="h-6 w-6" />
         </Link>
       ))}
     </div>
   )
 }
 
-const linkIconData: LinkIconData[] = [
+const channels: Channels[] = [
   {
     id: 0,
+    name: 'HAEDAL Email',
     href: 'mailto:knu.haedal@gmail.com',
     icon: EnvelopeClosedIcon,
-    alt: 'HAEDAL Email Link',
   },
   {
     id: 1,
+    name: 'HAEDAL GitHub',
     href: 'https://github.com/KNU-HAEDAL',
     icon: GitHubLogoIcon,
-    alt: 'HAEDAL Github Link',
   },
   {
     id: 2,
+    name: 'HAEDAL Instagram',
     href: 'https://www.instagram.com/knu.haedal/',
     icon: InstagramLogoIcon,
-    alt: 'HAEDAL Instagram Link',
   },
 ]

--- a/src/app/(main)/_components/footer/Footer.tsx
+++ b/src/app/(main)/_components/footer/Footer.tsx
@@ -21,7 +21,9 @@ export const Footer = () => {
         </p>
       </div>
       <FooterDetail />
-      <p className="text-xs">© 2024 해달. All rights reserved.</p>
+      <p className="text-xs text-slate-500">
+        © 2024 해달. All rights reserved.
+      </p>
       <LinkIcon />
     </div>
   )

--- a/src/app/(main)/_components/footer/Footer.tsx
+++ b/src/app/(main)/_components/footer/Footer.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 
+import { ChannelIcons } from './ChannelIcons'
 import { FooterDetail } from './FooterDetail'
-import { LinkIcon } from './LinkIcon'
 
 export const Footer = () => {
   return (
@@ -24,26 +24,7 @@ export const Footer = () => {
       <p className="text-xs text-slate-500">
         © 2024 해달. All rights reserved.
       </p>
-      <LinkIcon />
+      <ChannelIcons />
     </div>
   )
 }
-
-// const [itemCount, setItemCount] = useState(12)
-
-// useEffect(() => {
-//   const updateItemCount = () => {
-//     if (window.innerWidth < 640) {
-//       setItemCount(9)
-//     } else {
-//       setItemCount(12)
-//     }
-//   }
-
-//   updateItemCount()
-//   window.addEventListener('resize', updateItemCount)
-
-//   return () => {
-//     window.removeEventListener('resize', updateItemCount)
-//   }
-// }, [])

--- a/src/app/(main)/_components/footer/Footer.tsx
+++ b/src/app/(main)/_components/footer/Footer.tsx
@@ -26,3 +26,22 @@ export const Footer = () => {
     </div>
   )
 }
+
+// const [itemCount, setItemCount] = useState(12)
+
+// useEffect(() => {
+//   const updateItemCount = () => {
+//     if (window.innerWidth < 640) {
+//       setItemCount(9)
+//     } else {
+//       setItemCount(12)
+//     }
+//   }
+
+//   updateItemCount()
+//   window.addEventListener('resize', updateItemCount)
+
+//   return () => {
+//     window.removeEventListener('resize', updateItemCount)
+//   }
+// }, [])

--- a/src/app/(main)/_components/footer/FooterDetail.tsx
+++ b/src/app/(main)/_components/footer/FooterDetail.tsx
@@ -6,7 +6,7 @@ type FooterDetailData = {
 
 export const FooterDetail = () => {
   return (
-    <div className="flex flex-col justify-start gap-6 text-sm sm:flex-col sm:gap-2">
+    <div className="flex flex-col justify-start gap-2 text-sm">
       {footerDetailData.map((detail) => (
         <div key={detail.id} className="flex flex-row gap-4">
           <span className="whitespace-nowrap break-keep font-semibold">

--- a/src/app/(main)/_components/footer/FooterDetail.tsx
+++ b/src/app/(main)/_components/footer/FooterDetail.tsx
@@ -9,8 +9,10 @@ export const FooterDetail = () => {
     <div className="flex flex-col justify-start gap-6 text-sm sm:flex-col sm:gap-2">
       {footerDetailData.map((detail) => (
         <div key={detail.id} className="flex flex-row gap-4">
-          <div className="font-semibold">{detail.label}</div>
-          <div>{detail.content}</div>
+          <span className="whitespace-nowrap break-keep font-semibold">
+            {detail.label}
+          </span>
+          <span className="break-keep">{detail.content}</span>
         </div>
       ))}
     </div>

--- a/src/app/(main)/_components/footer/LinkIcon.tsx
+++ b/src/app/(main)/_components/footer/LinkIcon.tsx
@@ -17,7 +17,7 @@ type LinkIconData = {
 
 export const LinkIcon = () => {
   return (
-    <div className="absolute bottom-8 right-12 flex gap-4">
+    <div className="bottom-8 right-12 flex gap-4 sm:absolute">
       {linkIconData.map((linkIcon) => (
         <Link href={linkIcon.href} key={linkIcon.id}>
           <linkIcon.icon className="h-6 w-6" />


### PR DESCRIPTION
### 📝 상세 내용
- 푸터 모바일 뷰에서 글자 줄바꿈이 생기고 아이콘 위치가 안 맞아서 그 부분 수정하였습니다.  
- LinkIcon이라고 되어있는 컴포넌트 이름이 뭔가 적절하지 않은 것 같아서 ChannelIcons로 바꾸었어요.  
바꾸면서 같이 이름 바꾼 것도 있습니다.

### #️⃣ 이슈 번호
- closes #57 

### 📷 스크린샷(선택)
<div style={{ display: 'flex', alignItems: 'center' }}>
  <img src="https://github.com/user-attachments/assets/b03cafe8-fdcf-41ac-8779-987c91f81fe3" width="300" />
  <span>→</span>
  <img src="https://github.com/user-attachments/assets/fb44d782-d03b-4180-a7ce-71de05443bd8" width="300" />
</div>
