### PR TITLE
fix: reissue 에러 수정

### DIFF
--- a/frontend/src/service/api/auth/reissue.ts
+++ b/frontend/src/service/api/auth/reissue.ts
@@ -3,12 +3,10 @@ import { Reissue } from '@/service/model'
 import { useAuthStore } from '@/store/auth'
 
 export const reissueApi = async () => {
-  const { accessToken, setAccessToken } = useAuthStore.getState()
+  const { setAccessToken } = useAuthStore.getState()
 
   const reissueClient = new Reissue(BACKEND_API)
-  const response = await reissueClient.reissue({
-    headers: { Authorization: accessToken },
-  })
+  const response = await reissueClient.reissue()
 
   const newAccessToken = response.headers['authorization']
   setAccessToken(newAccessToken)

--- a/frontend/src/service/config/interceptor/auth-error.ts
+++ b/frontend/src/service/config/interceptor/auth-error.ts
@@ -1,7 +1,9 @@
 import { AxiosError } from 'axios'
+import { toast } from 'sonner'
 
-import { reissueApi } from '@/service/api'
+import { logoutApi, reissueApi } from '@/service/api'
 import { AUTHORIZATION_API } from '@/service/config'
+import { useMyInfoStore } from '@/store'
 
 let isRefreshing = false
 let failedQueue: {
@@ -36,7 +38,8 @@ const authErrorInterceptor = async (error: AxiosError) => {
             .then((newAccessToken) => {
               processQueue(null, newAccessToken)
             })
-            .catch((reissueError) => {
+            .catch(async (reissueError) => {
+              await handleLogout()
               processQueue(reissueError, null)
             })
             .finally(() => {
@@ -57,6 +60,14 @@ const authErrorInterceptor = async (error: AxiosError) => {
   }
 
   return Promise.reject(error)
+}
+
+const handleLogout = async () => {
+  const clearMyInfo = useMyInfoStore.getState().clearMyInfo
+
+  await logoutApi()
+  clearMyInfo()
+  toast('로그아웃되었습니다.')
 }
 
 export default authErrorInterceptor


### PR DESCRIPTION
### 📝 상세 내용

- reissue api를 호출할 때, header의 access token를 제거했습니다.
  - 토큰 갱신은 백엔드에서 cookie의 refresh token으로 진행하므로 access token은 필요없음
  - access token을 포함해서 api를 호출하면, 401 에러가 먼저 반환되어 reissue 작업이 안이루어짐
- refresh token의 유효기간이 만료되었을 때, 로그아웃하는 기능을 추가했습니다.

### #️⃣ 이슈 번호
- close #114 


### 🔗 참고 자료



### 📷 스크린샷(선택)


