### PR TITLE
fix: 마이페이지 정보 수정 후 화면에 반환하기

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,12 @@ jobs:
 
       - name: Install Dependencies
         run: npm install
+        working-directory: ./frontend
 
       - name: Lint Code
         run: npm run lint
+        working-directory: ./frontend
 
       - name: Build Test
         run: npm run build
+        working-directory: ./frontend

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -25,7 +25,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
+    className={cn('aspect-square h-full w-full object-cover', className)}
     {...props}
   />
 ))

--- a/frontend/src/pages/mypage/_components/user-info/UserInfoSection.tsx
+++ b/frontend/src/pages/mypage/_components/user-info/UserInfoSection.tsx
@@ -59,7 +59,7 @@ export const UserInfoSection = ({ profile, userId }: UserInfoSectionProps) => {
     toast.success(message, { duration: 2000 })
 
     queryClient.invalidateQueries({
-      queryKey: profileQuries.profiles({ userId: profile.userId }),
+      queryKey: profileQuries.all(),
     })
   }
 

--- a/frontend/src/pages/mypage/_components/user-info/UserInfoSection.tsx
+++ b/frontend/src/pages/mypage/_components/user-info/UserInfoSection.tsx
@@ -28,6 +28,7 @@ import {
   UpdateProfileImage,
   UpdateProfileImageSchema,
 } from '@/service/schema/mypage'
+import { useMyInfoStore } from '@/store'
 import { convertRoleName } from '@/utils'
 
 interface UserInfoSectionProps {
@@ -36,6 +37,8 @@ interface UserInfoSectionProps {
 }
 
 export const UserInfoSection = ({ profile, userId }: UserInfoSectionProps) => {
+  const setMyInfo = useMyInfoStore((state) => state.setMyInfo)
+
   const form = useForm<UpdateProfileImage>({
     resolver: zodResolver(UpdateProfileImageSchema),
     defaultValues: {
@@ -55,12 +58,18 @@ export const UserInfoSection = ({ profile, userId }: UserInfoSectionProps) => {
     onSuccess: (data) => onSuccess(data.message),
   })
 
-  const onSuccess = (message?: string) => {
+  const onSuccess = async (message?: string) => {
     toast.success(message, { duration: 2000 })
 
     queryClient.invalidateQueries({
       queryKey: profileQuries.all(),
     })
+
+    const { profileImageUrl: profileImage } = await queryClient.fetchQuery(
+      profileQuries.profile({ userId }),
+    )
+
+    setMyInfo({ profileImage })
   }
 
   const onClickUploadButton = () => {

--- a/frontend/src/pages/mypage/_components/user-social-info/UserSocialInfoSection.tsx
+++ b/frontend/src/pages/mypage/_components/user-social-info/UserSocialInfoSection.tsx
@@ -56,7 +56,7 @@ export const UserSocialInfoSection = ({
 
     queryClient
       .invalidateQueries({
-        queryKey: profileQuries.profiles({ userId: userId }),
+        queryKey: profileQuries.all(),
       })
       .then(() => {
         form.reset(form.getValues())

--- a/frontend/src/store/myInfo.ts
+++ b/frontend/src/store/myInfo.ts
@@ -12,7 +12,7 @@ export type MyInfo = {
 
 interface MyInfoProps {
   myInfo: MyInfo
-  setMyInfo: (myInfo: MyInfo) => void
+  setMyInfo: (myInfo: Partial<MyInfo>) => void
   clearMyInfo: () => void
 }
 
@@ -20,7 +20,10 @@ export const useMyInfoStore = create(
   persist<MyInfoProps>(
     (set) => ({
       myInfo: { userId: '', userName: '', role: undefined, profileImage: '' },
-      setMyInfo: (myInfo) => set({ myInfo }),
+      setMyInfo: (partialInfo: Partial<MyInfo>) =>
+        set((state) => ({
+          myInfo: { ...state.myInfo, ...partialInfo },
+        })),
       clearMyInfo: () =>
         set({
           myInfo: {


### PR DESCRIPTION
### 📝 상세 내용

- 프로필 사진 변경, 프로필 정보 변경 후 초기화되는 queryKey를 수정했습니다.
    - query 초기화가 발생되어야하는 부분: 멤버 페이지에서 profile lsit 조회(`profileQuries.list`), 마이페이지에서 profile 조회(`profileQuries.profile`)
    - 두 query key를 포함하는 상위 query로(`profileQuries.all) 사용했습니다.
    ```diff
    - queryKey: profileQuries.profiles({ userId: profile.userId })
    + queryKey: profileQuries.all()
     ```
- useMyInfoStore의 setMyInfo를 리팩토링했습니다.
  - MyInfo를 객체가 아닌 Partial로 받아 특정 부분만 수정가능합니다.

- Avatar 컴포넌트의 이미지 원본 비율을 유지하기 위해 `object-cover` style을 추가했습니다.
  - 눈에 보였는데 따로 이슈 만들기에 마이너해서 같이 PR 날립니다.

### #️⃣ 이슈 번호
- close #105 


### 🔗 참고 자료



### 📷 스크린샷(선택)


