### PR TITLE
Feature: 회원가입시 회원가입 연도와 학기를 추가

### DIFF
--- a/frontend/src/pages/auth/singup/components/form/Form.tsx
+++ b/frontend/src/pages/auth/singup/components/form/Form.tsx
@@ -15,6 +15,7 @@ import {
   CheckUserIdField,
   SignupCheckboxField,
   SignupInputField,
+  SignupSelectField,
   VerifyUserEmailField,
 } from './field'
 import { SignupSuccessDialog } from './success-dialog'
@@ -44,6 +45,8 @@ export const SignupForm = () => {
       studentNumber: '',
       userName: '',
       checked: false,
+      year: '',
+      term: undefined,
     },
   })
 
@@ -61,8 +64,9 @@ export const SignupForm = () => {
         throw new Error('이메일 인증을 진행해주세요.')
       }
 
-      const { userId, password, email, studentNumber, userName } =
+      const { userId, password, email, studentNumber, userName, year, term } =
         form.getValues()
+      const joinSemester = 'SEMESTER_' + year + '_' + term
 
       signup({
         data: {
@@ -71,6 +75,7 @@ export const SignupForm = () => {
           email,
           studentNumber: Number(studentNumber),
           userName,
+          joinSemester,
         },
       })
     } catch (error) {
@@ -119,6 +124,24 @@ export const SignupForm = () => {
             formLabel="이름"
             placeholder="호반우"
           />
+        </div>
+        <div className="flex justify-center gap-2">
+          <div className="flex-1">
+            <SignupInputField
+              name="year"
+              formLabel="해달 가입 연도"
+              placeholder="2025"
+              formDescription="- 연도는 4자리 숫자만 작성해주세요."
+            />
+          </div>
+          <div className="flex-1">
+            <SignupSelectField
+              name="term"
+              formLabel="해달 가입 학기"
+              placeholder="학기"
+              selectItem={{ '1': '1학기', '2': '2학기' }}
+            />
+          </div>
         </div>
         <div className="space-y-2">
           <CheckUserEmailField

--- a/frontend/src/pages/auth/singup/components/form/field/index.ts
+++ b/frontend/src/pages/auth/singup/components/form/field/index.ts
@@ -1,3 +1,4 @@
 export * from './checkbox'
 export * from './input'
 export * from './check-input'
+export * from './select'

--- a/frontend/src/pages/auth/singup/components/form/field/select/SelectField.tsx
+++ b/frontend/src/pages/auth/singup/components/form/field/select/SelectField.tsx
@@ -1,0 +1,71 @@
+import { InputHTMLAttributes } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui'
+
+interface SignupSelectFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  name: string
+  formLabel: string
+  placeholder?: string
+  formDescription?: string
+  selectItem?: Record<string, string>
+}
+
+export const SignupSelectField = ({
+  name,
+  formLabel,
+  formDescription,
+  placeholder,
+  selectItem,
+}: SignupSelectFieldProps) => {
+  const { control } = useFormContext()
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => {
+        return (
+          <FormItem>
+            <FormLabel>{formLabel}</FormLabel>
+            <FormControl>
+              <div className="flex gap-2">
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder={placeholder} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {selectItem &&
+                      Object.entries(selectItem).map(([value, label]) => (
+                        <SelectItem key={value} value={value}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </FormControl>
+            {formDescription && (
+              <FormDescription className="pl-2">
+                {formDescription}
+              </FormDescription>
+            )}
+            <FormMessage className="pl-2" />
+          </FormItem>
+        )
+      }}
+    />
+  )
+}

--- a/frontend/src/pages/auth/singup/components/form/field/select/index.ts
+++ b/frontend/src/pages/auth/singup/components/form/field/select/index.ts
@@ -1,0 +1,1 @@
+export { SignupSelectField } from './SelectField'

--- a/frontend/src/service/schema/auth.ts
+++ b/frontend/src/service/schema/auth.ts
@@ -39,6 +39,14 @@ export const SignupSchema = z.object({
       message: '안내 문구를 확인해주세요.',
     }),
   }),
+  year: z.string().regex(/^20[0-9]{2}$/, {
+    message: '잘못된 연도 입력입니다.',
+  }),
+  term: z.enum(['1', '2'], {
+    errorMap: () => ({
+      message: '1학기, 2학기 중에 하나를 입력해주세요.',
+    }),
+  }),
 })
 export type Signup = z.infer<typeof SignupSchema>
 


### PR DESCRIPTION
### 📝 상세 내용
가입 시기별로 동아리원들을 구분하기 위해 회원가입시기 입력란을 추가했습니다. 
연도는 숫자 4자리로 입력하고 학기는 select를 사용하여 구현하였습니다. 


### #️⃣ 이슈 번호
- #145 


### 🔗 참고 자료

### 📷 스크린샷(선택)
<img width="1121" alt="회원가입시 연도, 학기 추가" src="https://github.com/user-attachments/assets/063a5c99-760c-4a3e-8aaf-8fffca953935" />

회원가입 폼에 추가된 모습입니다. 


<img width="756" alt="테스트용 요청 결과" src="https://github.com/user-attachments/assets/a11951e9-7729-426b-b6b7-b912be3fbdc4" />

회원가입 요청이 동작하는 것을 확인했습니다. 