### PR TITLE
Feature: 멤버 페이지 가입학기로 구분하여 멤버 보여주게 변경

### DIFF
--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -5,7 +5,7 @@ import { ArrowRightIcon } from '@radix-ui/react-icons'
 
 import { IntersectionObserverLoader } from '@/components/common'
 import { MemberCard } from '@/components/feature'
-import { Button } from '@/components/ui'
+import { Button, Pagination } from '@/components/ui'
 import { useProfileSuspensePaging } from '@/service/api'
 
 export default function MemberPage() {
@@ -21,7 +21,7 @@ export default function MemberPage() {
     isFetchingNextPage,
     fetchNextPage,
   } = useProfileSuspensePaging({
-    roles: ['ROLE_MEMBER', 'ROLE_ADMIN', 'ROLE_WEB_MASTER', 'ROLE_TEAM_LEADER'],
+    roles: ['ROLE_MEMBER', 'ROLE_ADMIN', 'ROLE_TEAM_LEADER'],
     joinSemester: `SEMESTER_${year}_${semester}`,
   })
 
@@ -63,16 +63,20 @@ export default function MemberPage() {
           )
         })}
       </div>
-      <div className="pt-10 text-xl font-semibold">
-        <button
+      <div className="flex items-center gap-2 pt-10 text-xl font-semibold">
+        <Pagination
           onClick={handleLeftSemester}
-          className={year === '2024' && semester === '1' ? 'invisible' : ''}
-        >{`< `}</button>{' '}
-        {`${year}-${semester}`} 멤버{' '}
-        <button
+          className={
+            year === '2024' && semester === '1' ? 'invisible' : 'cursor-pointer'
+          }
+        >{`< `}</Pagination>
+        <span className="whitespace-nowrap">{`${year}-${semester}`} 멤버</span>
+        <Pagination
           onClick={handleRightSemester}
-          className={year === '2029' && semester === '2' ? 'invisible' : ''}
-        >{` >`}</button>
+          className={
+            year === '2029' && semester === '2' ? 'invisible' : 'cursor-pointer'
+          }
+        >{` >`}</Pagination>
       </div>
       <div className="text-md text-primary/60">
         해달과 {memberProfiles.length}명의 부원들이 함께 하고 있어요

--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { ArrowRightIcon } from '@radix-ui/react-icons'
@@ -11,24 +12,41 @@ export default function MemberPage() {
   const navigate = useNavigate()
   const { data: admin } = useProfileSuspensePaging({ roles: ['ROLE_ADMIN'] })
 
+  const [year, setYear] = useState('2025')
+  const [semester, setSemester] = useState('1')
+
   const {
     data: member,
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useProfileSuspensePaging({ roles: ['ROLE_MEMBER'] })
+  } = useProfileSuspensePaging({
+    roles: ['ROLE_MEMBER', 'ROLE_ADMIN', 'ROLE_WEB_MASTER', 'ROLE_TEAM_LEADER'],
+    joinSemester: `SEMESTER_${year}_${semester}`,
+  })
 
+  const handleLeftSemester = () => {
+    if (semester === '1') {
+      setSemester('2')
+      setYear((prev) => String(Number(prev) - 1))
+    } else {
+      setSemester('1')
+    }
+  }
+  const handleRightSemester = () => {
+    if (semester === '2') {
+      setSemester('1')
+      setYear((prev) => String(Number(prev) + 1))
+    } else {
+      setSemester('2')
+    }
+  }
   const adminProfiles = admin?.pages.flatMap((page) => page.profiles)
   const memberProfiles = member?.pages.flatMap((page) => page.profiles)
 
   return (
     <main className="flex h-full w-full flex-col items-center pb-20">
-      <div className="text-xl font-semibold">2025-1 멤버</div>
-      <div className="text-md text-primary/60">
-        해달과 {adminProfiles.length + memberProfiles.length}명의 부원들이 함께
-        하고 있어요
-      </div>
-      <div className="w-full max-w-[920px] pb-4 pt-10 text-xl font-semibold">
+      <div className="w-full max-w-[920px] pb-4 text-xl font-semibold">
         해구르르
       </div>
       <div className="grid w-full max-w-[320px] grid-cols-2 place-items-center gap-6 sm:max-w-[520px] sm:grid-cols-3 md:max-w-[680px] lg:max-w-[920px] lg:grid-cols-4">
@@ -44,6 +62,20 @@ export default function MemberPage() {
             />
           )
         })}
+      </div>
+      <div className="pt-10 text-xl font-semibold">
+        <button
+          onClick={handleLeftSemester}
+          className={year === '2024' && semester === '1' ? 'invisible' : ''}
+        >{`< `}</button>{' '}
+        {`${year}-${semester}`} 멤버{' '}
+        <button
+          onClick={handleRightSemester}
+          className={year === '2029' && semester === '2' ? 'invisible' : ''}
+        >{` >`}</button>
+      </div>
+      <div className="text-md text-primary/60">
+        해달과 {memberProfiles.length}명의 부원들이 함께 하고 있어요
       </div>
       <div className="w-full max-w-[920px] pb-4 pt-10 text-xl font-semibold">
         정회원 & 준회원

--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -5,7 +5,7 @@ import { ArrowRightIcon } from '@radix-ui/react-icons'
 
 import { IntersectionObserverLoader } from '@/components/common'
 import { MemberCard } from '@/components/feature'
-import { Button, Pagination } from '@/components/ui'
+import { Button, PaginationNext, PaginationPrevious } from '@/components/ui'
 import { useProfileSuspensePaging } from '@/service/api'
 
 export default function MemberPage() {
@@ -67,21 +67,19 @@ export default function MemberPage() {
         })}
       </div>
       <div className="flex items-center gap-2 pt-10 text-xl font-semibold">
-        <Pagination
+        <PaginationPrevious
+          to="#"
           onClick={handleLeftSemester}
-          className={
-            year === '2024' && semester === '1' ? 'invisible' : 'cursor-pointer'
-          }
-        >{`< `}</Pagination>
-        <span className="whitespace-nowrap">{`${year}-${semester}`} 멤버</span>
-        <Pagination
+          disabled={year === '2024' && semester === '1'}
+          className={'cursor-pointer'}
+        />
+        <span>{`${year}-${semester}`} 멤버</span>
+        <PaginationNext
+          to="#"
+          disabled={year === nowYear && semester === nowSemester}
           onClick={handleRightSemester}
-          className={
-            year === nowYear && semester === nowSemester
-              ? 'invisible'
-              : 'cursor-pointer'
-          }
-        >{` >`}</Pagination>
+          className={'cursor-pointer'}
+        />
       </div>
       <div className="text-md text-primary/60">
         해달과 {memberProfiles.length}명의 부원들이 함께 하고 있어요

--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -12,8 +12,11 @@ export default function MemberPage() {
   const navigate = useNavigate()
   const { data: admin } = useProfileSuspensePaging({ roles: ['ROLE_ADMIN'] })
 
-  const [year, setYear] = useState('2025')
-  const [semester, setSemester] = useState('1')
+  const nowYear = String(new Date().getFullYear())
+  const nowSemester = new Date().getMonth() < 9 ? '1' : '2'
+
+  const [year, setYear] = useState(nowYear)
+  const [semester, setSemester] = useState(nowSemester)
 
   const {
     data: member,
@@ -74,7 +77,9 @@ export default function MemberPage() {
         <Pagination
           onClick={handleRightSemester}
           className={
-            year === '2029' && semester === '2' ? 'invisible' : 'cursor-pointer'
+            year === nowYear && semester === nowSemester
+              ? 'invisible'
+              : 'cursor-pointer'
           }
         >{` >`}</Pagination>
       </div>

--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -13,7 +13,7 @@ export default function MemberPage() {
   const { data: admin } = useProfileSuspensePaging({ roles: ['ROLE_ADMIN'] })
 
   const nowYear = String(new Date().getFullYear())
-  const nowSemester = new Date().getMonth() < 9 ? '1' : '2'
+  const nowSemester = new Date().getMonth() < 8 ? '1' : '2'
 
   const [year, setYear] = useState(nowYear)
   const [semester, setSemester] = useState(nowSemester)

--- a/frontend/src/service/model/Users.ts
+++ b/frontend/src/service/model/Users.ts
@@ -196,6 +196,20 @@ export class Users<
         | 'ROLE_TEAM_LEADER'
         | 'ROLE_MEMBER'
       )[]
+      /** 가입학기로 필터링 (ex: SEMESTER_2024_1) */
+      joinSemester?:
+        | 'SEMESTER_2024_1'
+        | 'SEMESTER_2024_2'
+        | 'SEMESTER_2025_1'
+        | 'SEMESTER_2025_2'
+        | 'SEMESTER_2026_1'
+        | 'SEMESTER_2026_2'
+        | 'SEMESTER_2027_1'
+        | 'SEMESTER_2027_2'
+        | 'SEMESTER_2028_1'
+        | 'SEMESTER_2028_2'
+        | 'SEMESTER_2029_1'
+        | 'SEMESTER_2029_2'
     },
     params: RequestParams = {},
   ) =>

--- a/frontend/src/service/model/request.d.ts
+++ b/frontend/src/service/model/request.d.ts
@@ -107,6 +107,7 @@ export type GetProfilePagingRequest = {
   page?: string
   size?: number
   roles: Role[]
+  joinSemester?: string
 }
 
 export type ProfilePagingProps = {

--- a/frontend/src/types/data.d.ts
+++ b/frontend/src/types/data.d.ts
@@ -9,3 +9,18 @@ export type Role =
   | 'ROLE_ADMIN'
   | 'ROLE_TEAM_LEADER'
   | 'ROLE_MEMBER'
+
+export type SemesterCode =
+  | 'SEMESTER_2024_1'
+  | 'SEMESTER_2024_2'
+  | 'SEMESTER_2025_1'
+  | 'SEMESTER_2025_2'
+  | 'SEMESTER_2026_1'
+  | 'SEMESTER_2026_2'
+  | 'SEMESTER_2027_1'
+  | 'SEMESTER_2027_2'
+  | 'SEMESTER_2028_1'
+  | 'SEMESTER_2028_2'
+  | 'SEMESTER_2029_1'
+  | 'SEMESTER_2029_2'
+  | undefined


### PR DESCRIPTION
### 📝 상세 내용

멤버 페이지에 학기 별로 멤버를 볼 수 있게 변경했습니다.


### #️⃣ 이슈 번호

- #147 

### 🔗 참고 자료



### 📷 스크린샷(선택)

![스크린샷 2025-05-12 184054](https://github.com/user-attachments/assets/b287aa42-30b0-41ba-8af1-9fa434ec0c4e)


![스크린샷 2025-05-12 190302](https://github.com/user-attachments/assets/8f3a6ad5-e8cc-4448-b823-e46554a0fb17)

기존 인원은 학기가 등록되어있지 않아서 나오지 않는 상황입니다., 