### PR TITLE
Fix: 2024-1 이전 가입자 회원가입시 오류 발생

### DIFF
--- a/frontend/src/service/api/user/user.ts
+++ b/frontend/src/service/api/user/user.ts
@@ -32,3 +32,10 @@ export const UserQuries = {
       queryFn: async () => getUser({ userId }),
     }),
 }
+
+export const getJoinSemestersApi = async () => {
+  const userClient = new Users(AUTHORIZATION_API)
+  const response = await userClient.getJoinSemesters()
+
+  return response.data
+}

--- a/frontend/src/service/model/Users.ts
+++ b/frontend/src/service/model/Users.ts
@@ -12,6 +12,7 @@ import { ContentType, RequestParams } from '@/lib/http-client'
 
 import { CustomHttpClient } from '../config'
 import {
+  GetJoinSemestersData,
   GetProfileData,
   GetProfilesData,
   GetUserData,
@@ -220,6 +221,23 @@ export class Users<
         ...query,
         roles: query.roles.join(', '),
       },
+      secure: true,
+      ...params,
+    })
+  /**
+   * No description
+   *
+   * @tags 유저 API
+   * @name GetJoinSemesters
+   * @summary 유저 가입 학기 목록 조회
+   * @request GET:/users/join-semesters
+   * @secure
+   * @response `200` `GetJoinSemestersData` OK
+   */
+  getJoinSemesters = (params: RequestParams = {}) =>
+    this.request<GetJoinSemestersData, any>({
+      path: `/users/join-semesters`,
+      method: 'GET',
       secure: true,
       ...params,
     })

--- a/frontend/src/service/model/data-contracts.ts
+++ b/frontend/src/service/model/data-contracts.ts
@@ -407,6 +407,21 @@ export interface ActivityResponseDto {
   semesterId: number
 }
 
+export type GetJoinSemestersData = (
+  | 'SEMESTER_2024_1'
+  | 'SEMESTER_2024_2'
+  | 'SEMESTER_2025_1'
+  | 'SEMESTER_2025_2'
+  | 'SEMESTER_2026_1'
+  | 'SEMESTER_2026_2'
+  | 'SEMESTER_2027_1'
+  | 'SEMESTER_2027_2'
+  | 'SEMESTER_2028_1'
+  | 'SEMESTER_2028_2'
+  | 'SEMESTER_2029_1'
+  | 'SEMESTER_2029_2'
+)[]
+
 export interface FindUserIdResponseDto {
   /**
    * 유저 아이디
@@ -702,7 +717,6 @@ export interface AdminUserResponseDto {
    */
   regDate: string
 }
-
 export interface BoardResponseDto {
   /**
    * 게시판 id

--- a/frontend/src/service/schema/auth.ts
+++ b/frontend/src/service/schema/auth.ts
@@ -39,14 +39,27 @@ export const SignupSchema = z.object({
       message: '안내 문구를 확인해주세요.',
     }),
   }),
-  year: z.string().regex(/^20[0-9]{2}$/, {
-    message: '잘못된 연도 입력입니다.',
-  }),
-  term: z.enum(['1', '2'], {
-    errorMap: () => ({
-      message: '1학기, 2학기 중에 하나를 입력해주세요.',
-    }),
-  }),
+  joinSemester: z.enum(
+    [
+      'SEMESTER_2024_1',
+      'SEMESTER_2024_2',
+      'SEMESTER_2025_1',
+      'SEMESTER_2025_2',
+      'SEMESTER_2026_1',
+      'SEMESTER_2026_2',
+      'SEMESTER_2027_1',
+      'SEMESTER_2027_2',
+      'SEMESTER_2028_1',
+      'SEMESTER_2028_2',
+      'SEMESTER_2029_1',
+      'SEMESTER_2029_2',
+    ],
+    {
+      errorMap: () => ({
+        message: '가입 학기를 선택해주세요.',
+      }),
+    },
+  ),
 })
 export type Signup = z.infer<typeof SignupSchema>
 


### PR DESCRIPTION
### 📝 상세 내용
가입 학기를 입력할 때 가능한 년도는 2024-1 까지인데 입력 받는 폼으로 했을 때 그 이전 시기를 입력하면 오류가 발생하는 현상이 있었습니다. 

1. 가용가입학기를 api를 통해 가져와 그 범위만큼을 셀렉트박스로 한번에 선택할 수 있게 변경하였습니다. 
2. 멤버 페이지에서도 가용가입학기 만큼 학기를 변경할 수 있도록 변경하였습니다. 

### #️⃣ 이슈 번호
- #149 

### 🔗 참고 자료



### 📷 스크린샷(선택)
![image](https://github.com/user-attachments/assets/ed26a213-2c67-4184-8166-04f33ac0855c)

![스크린샷 2025-05-26 162725](https://github.com/user-attachments/assets/8f4eee6c-7668-4d64-95c3-32da615d8835)

![스크린샷 2025-05-26 165800](https://github.com/user-attachments/assets/9bd24ddf-1d60-43e7-9aee-a8c9c26289e1)
