### PR TITLE
Fix: userId 스키마에 영문+숫자 혼합 필수 조건 추가

### DIFF
--- a/frontend/src/service/schema/auth.ts
+++ b/frontend/src/service/schema/auth.ts
@@ -11,8 +11,8 @@ export const SignupSchema = z.object({
     .string()
     .min(6, { message: 'ID는 6자 이상여야 합니다.' })
     .max(12, { message: 'ID는 12자 이하여야 합니다.' })
-    .regex(/^[A-Za-z0-9]+$/, {
-      message: 'ID는 영어와 숫자만 입력할 수 있습니다.',
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9]+$/, {
+      message: 'ID는 영어와 숫자를 혼용하여 설정해야 합니다.',
     }),
   password: z
     .string()
@@ -79,8 +79,8 @@ export const ResetPasswordSchema = z.object({
     .string()
     .min(6, { message: 'ID는 6자 이상여야 합니다.' })
     .max(12, { message: 'ID는 12자 이하여야 합니다.' })
-    .regex(/^[A-Za-z0-9]+$/, {
-      message: 'ID는 영어와 숫자만 입력할 수 있습니다.',
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9]+$/, {
+      message: 'ID는 영어와 숫자를 혼용하여 설정해야 합니다.',
     }),
   studentNumber: z.string().length(10, {
     message: '학번은 10자여야 합니다.',


### PR DESCRIPTION
### 📝 상세 내용
스키마 파일 내에 userId를 사용하는 부분에 숫자와 영어가 들어있는지 검사하는 부분을 추가해 
id가 영어+숫자로 되어있는지 검증하도록 수정하였습니다. 


### #️⃣ 이슈 번호
- #151 


### 🔗 참고 자료



### 📷 스크린샷(선택)

![스크린샷 2025-05-27 203731](https://github.com/user-attachments/assets/9609172e-81c2-4d3b-80ab-0775b16078cf)

![스크린샷 2025-05-27 203739](https://github.com/user-attachments/assets/fd87aa1f-4eb2-4506-8ef6-65e49b5f7f5c)

![스크린샷 2025-05-27 203747](https://github.com/user-attachments/assets/4425b958-6df3-430d-aeea-3398564c22ea)
