### PR TITLE
Feature: 멤버 페이지에서 연도별 해구르르 정보 업데이트 가능하게 추가

### DIFF
--- a/frontend/src/components/feature/comment/list/item/profile-avatar/ProfileAvatar.tsx
+++ b/frontend/src/components/feature/comment/list/item/profile-avatar/ProfileAvatar.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui'
-import { profileQuries } from '@/service/api'
+import { profileQueries } from '@/service/api'
 import { BASE_URL } from '@/service/config'
 
 interface ProfileAvatarProps {
@@ -13,7 +13,7 @@ export const ProfileAvatar = ({ userId }: ProfileAvatarProps) => {
     data: profile,
     status,
     error,
-  } = useQuery(profileQuries.profile({ userId }))
+  } = useQuery(profileQueries.profile({ userId }))
 
   if (status === 'pending' || error)
     return (

--- a/frontend/src/data/admin/2025.ts
+++ b/frontend/src/data/admin/2025.ts
@@ -13,11 +13,11 @@ export const admins2025: Admin<Position2025>[] = [
   },
   {
     position: '부회장',
-    userId: 'ezzkim1',
+    userId: 'song123',
   },
   {
     position: '총무',
-    userId: 'song123',
+    userId: 'ezzkim1',
   },
   {
     position: '교육운영진장',

--- a/frontend/src/data/admin/2025.ts
+++ b/frontend/src/data/admin/2025.ts
@@ -1,6 +1,12 @@
-import { Admin2025 } from '@/types'
+import { Admin, BasePosition } from '@/types'
 
-export const admins2025: Admin2025[] = [
+export type Position2025 =
+  | BasePosition
+  | '트랙조직위원장'
+  | '홍보부장'
+  | '기술관리부장'
+
+export const admins2025: Admin<Position2025>[] = [
   {
     position: '회장',
     userId: 'haedal2025',

--- a/frontend/src/data/admin/index.ts
+++ b/frontend/src/data/admin/index.ts
@@ -1,0 +1,1 @@
+export * from './2025'

--- a/frontend/src/data/index.ts
+++ b/frontend/src/data/index.ts
@@ -1,0 +1,1 @@
+export * from './admin'

--- a/frontend/src/pages/auth/login/components/form/Form.tsx
+++ b/frontend/src/pages/auth/login/components/form/Form.tsx
@@ -9,7 +9,7 @@ import { AxiosError } from 'axios'
 import { Button, Input, Label } from '@/components/ui'
 import { API_ERROR_MESSAGES } from '@/constant'
 import { queryClient } from '@/lib/query-client'
-import { loginApi, profileQuries } from '@/service/api'
+import { loginApi, profileQueries } from '@/service/api'
 import { Login, LoginSchema } from '@/service/schema'
 import { useAuthStore, useMyInfoStore } from '@/store'
 
@@ -58,7 +58,7 @@ export const LoginForm = () => {
 
     try {
       const myInfo = await queryClient.fetchQuery(
-        profileQuries.profile({ userId: form.getValues('userId') }),
+        profileQueries.profile({ userId: form.getValues('userId') }),
       )
 
       if (myInfo) {

--- a/frontend/src/pages/member/default/MemberPage.tsx
+++ b/frontend/src/pages/member/default/MemberPage.tsx
@@ -6,8 +6,6 @@ import { PaginationNext, PaginationPrevious } from '@/components/ui'
 import { getJoinSemestersApi, useProfileSuspensePaging } from '@/service/api'
 
 export default function MemberPage() {
-  const { data: admin } = useProfileSuspensePaging({ roles: ['ROLE_ADMIN'] })
-
   const [joinSemesterData, setJoinSemesterData] = useState<string[]>([])
   const [semesterIndex, setSemesterIndex] = useState<number>(0)
 
@@ -48,7 +46,6 @@ export default function MemberPage() {
     return `${year}-${semester} 멤버`
   }
 
-  const adminProfiles = admin?.pages.flatMap((page) => page.profiles)
   const memberProfiles = member?.pages.flatMap((page) => page.profiles)
 
   return (

--- a/frontend/src/pages/member/default/mock/admin-2025.ts
+++ b/frontend/src/pages/member/default/mock/admin-2025.ts
@@ -1,0 +1,32 @@
+import { Admin2025 } from '@/types'
+
+export const admins2025: Admin2025[] = [
+  {
+    position: '회장',
+    userId: 'haedal2025',
+  },
+  {
+    position: '부회장',
+    userId: 'ezzkim1',
+  },
+  {
+    position: '총무',
+    userId: 'song123',
+  },
+  {
+    position: '교육운영진장',
+    userId: 'churaly',
+  },
+  {
+    position: '트랙조직위원장',
+    userId: 'ysh0702',
+  },
+  {
+    position: '홍보부장',
+    userId: 'pigmal1',
+  },
+  {
+    position: '기술관리부장',
+    userId: 'rnjs5540',
+  },
+]

--- a/frontend/src/pages/member/default/mock/index.ts
+++ b/frontend/src/pages/member/default/mock/index.ts
@@ -1,1 +1,0 @@
-export * from './admin-2025'

--- a/frontend/src/pages/member/default/mock/index.ts
+++ b/frontend/src/pages/member/default/mock/index.ts
@@ -1,0 +1,1 @@
+export * from './admin-2025'

--- a/frontend/src/pages/mypage/MyPage.tsx
+++ b/frontend/src/pages/mypage/MyPage.tsx
@@ -1,7 +1,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
 
 import { Separator } from '@/components/ui'
-import { profileQuries } from '@/service/api'
+import { profileQueries } from '@/service/api'
 import { useMyInfoStore } from '@/store'
 
 import {
@@ -15,7 +15,7 @@ export default function MyPage() {
   const { userId } = useMyInfoStore((state) => state.myInfo)
 
   const { data: profile } = useSuspenseQuery(
-    profileQuries.profile({ userId: userId }),
+    profileQueries.profile({ userId: userId }),
   )
 
   return (

--- a/frontend/src/pages/mypage/_components/edit-profile-form/EditProfileForm.tsx
+++ b/frontend/src/pages/mypage/_components/edit-profile-form/EditProfileForm.tsx
@@ -18,7 +18,7 @@ import {
   Separator,
 } from '@/components/ui'
 import { queryClient } from '@/lib/query-client'
-import { profileQuries, updateProfileInfoApi } from '@/service/api'
+import { profileQueries, updateProfileInfoApi } from '@/service/api'
 import { ProfileResponseDto } from '@/service/model'
 import {
   UpdateProfileInfo,
@@ -52,7 +52,7 @@ export const EditProfileForm = ({ profile, userId }: EditProfileFormProps) => {
 
     queryClient
       .invalidateQueries({
-        queryKey: profileQuries.all(),
+        queryKey: profileQueries.all(),
       })
       .then(() => {
         form.reset(form.getValues())

--- a/frontend/src/pages/mypage/_components/profile-image/ProfileImage.tsx
+++ b/frontend/src/pages/mypage/_components/profile-image/ProfileImage.tsx
@@ -19,7 +19,7 @@ import {
 import { queryClient } from '@/lib/query-client'
 import {
   deleteProfileImageApi,
-  profileQuries,
+  profileQueries,
   updateProfileImageApi,
 } from '@/service/api/profile'
 import { BASE_URL } from '@/service/config'
@@ -61,11 +61,11 @@ export const ProfileImage = ({ profile, userId }: ProfileImageProps) => {
     toast.success(message, { duration: 2000 })
 
     queryClient.invalidateQueries({
-      queryKey: profileQuries.all(),
+      queryKey: profileQueries.all(),
     })
 
     const { profileImageUrl: profileImage } = await queryClient.fetchQuery(
-      profileQuries.profile({ userId }),
+      profileQueries.profile({ userId }),
     )
 
     setMyInfo({ profileImage })

--- a/frontend/src/service/api/profile/profile.ts
+++ b/frontend/src/service/api/profile/profile.ts
@@ -49,7 +49,7 @@ const getUserProfile = async ({ userId }: GetUserProfileRequest) => {
   return response.data
 }
 
-export const profileQuries = {
+export const profileQueries = {
   all: () => ['profile'],
   lists: ({
     roles,
@@ -57,14 +57,14 @@ export const profileQuries = {
   }: {
     roles: Role[]
     joinSemester?: string
-  }) => [...profileQuries.all(), 'lists', ...roles, joinSemester],
+  }) => [...profileQueries.all(), 'lists', ...roles, joinSemester],
   profiles: ({ userId }: GetUserProfileRequest) => [
-    ...profileQuries.all(),
+    ...profileQueries.all(),
     userId,
   ],
   profile: ({ userId }: GetUserProfileRequest) =>
     queryOptions({
-      queryKey: [...profileQuries.profiles({ userId })],
+      queryKey: [...profileQueries.profiles({ userId })],
       enabled: !!userId,
       queryFn: async () => getUserProfile({ userId }),
     }),
@@ -77,7 +77,7 @@ export const useProfileSuspensePaging = ({
   joinSemester,
 }: ProfilePagingProps) => {
   return useSuspenseInfiniteQuery({
-    queryKey: [...profileQuries.lists({ roles, joinSemester }), initPageToken],
+    queryKey: [...profileQueries.lists({ roles, joinSemester }), initPageToken],
     queryFn: ({ pageParam = initPageToken }) =>
       getProfilePaging({ page: pageParam, size, roles, joinSemester }),
     initialPageParam: initPageToken,

--- a/frontend/src/types/data.d.ts
+++ b/frontend/src/types/data.d.ts
@@ -25,12 +25,8 @@ export type SemesterCode =
   | 'SEMESTER_2029_2'
   | undefined
 
-type BasePosition = '회장' | '부회장' | '총무' | '교육운영진장'
-type Position2025 =
-  | BasePosition
-  | '트랙조직위원장'
-  | '홍보부장'
-  | '기술관리부장'
-
-type Admin = { position: BasePosition; userId: string }
-export type Admin2025 = Omit<Admin, 'position'> & { position: Position2025 }
+export type BasePosition = '회장' | '부회장' | '총무' | '교육운영진장'
+export type Admin<Position extends string = BasePosition> = {
+  position: Position
+  userId: string
+}

--- a/frontend/src/types/data.d.ts
+++ b/frontend/src/types/data.d.ts
@@ -24,3 +24,13 @@ export type SemesterCode =
   | 'SEMESTER_2029_1'
   | 'SEMESTER_2029_2'
   | undefined
+
+type BasePosition = '회장' | '부회장' | '총무' | '교육운영진장'
+type Position2025 =
+  | BasePosition
+  | '트랙조직위원장'
+  | '홍보부장'
+  | '기술관리부장'
+
+type Admin = { position: BasePosition; userId: string }
+export type Admin2025 = Omit<Admin, 'position'> & { position: Position2025 }


### PR DESCRIPTION
### 📝 상세 내용

- 해구르르 mock 데이터를 수정했습니다.

	- 유저가 수정 가능한 프로필 정보 데이터 제거
	- 회장, 부회장 등 해구르르 직책(position) 추가

#### 이전
```
export const ADMIN_PROFILE_MOCK = [
	{
		userId: 'haedal2025',
		userName: '서지혜',
		studentNumber: undefined,
		email: undefined,
		role: 'ROLE_ADMIN',
		profileImageUrl: 'https://avatars.githubusercontent.com/u/138651699?v=4',
		profileIntro: '안녕하세요 올해 최고존엄입니다~',
		githubAccount: 'swisdom784',
		instaAccount: 's_wisdom38',
		joinSemester: 'SEMESTER_2024_1',
	},
...
]
```

#### 이후
```js
const admins2025: Admin<Position2025>[] = [
	{
	  position: '회장',
	  userId: 'haedal2025',
	},
	...
]
  ```

### ❗️매년 해구르르 정보 업데이트하기

1. `/src/data/admin`에 연도.ts 생성하기
2. BasePosition을 기반으로 해당 연도의 직책 설정하기

	- BasePosition: '회장' | '부회장' | '총무' | '교육운영진장'
	- 트랙조직위원장, 홍보부장, 기술관리부장 등 매년 변동되는 직책을 추가로 정의합니다.

3. 해달 사이트에 가입한 해구르르 userId 추가하기
4. . `/src/pages/member/default/MemberPage.tsx`에서 adminQueries의 `admins2025` 데이터 변경하기

	- `특정 연도 운영진 정보` 주석있는 부분입니다.)

5. 배포하기


### #️⃣ 이슈 번호
- close #161 


### 🔗 참고 자료

- [연도 데이터 생성 예시(2025.ts)]()

### 📷 스크린샷(선택)
<img width="882" height="697" alt="image" src="https://github.com/user-attachments/assets/ccf73e28-5bb3-479e-a8c7-ce25f6d7a36c" />


