### PR TITLE
Fix/156 게시판 생성 및 수정 시 글자수 제한 수정

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -2,4 +2,10 @@ echo "let's check the code! =^ . ｡.^="
 
 npx lint-staged
 
-echo "✅ Pre-commit checks completed!"
+npm run lint:fix
+
+echo "🎉 Formatting Test completed!"
+
+npm run tsc
+
+echo "✅ Type Check completed!"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,14 +8,17 @@
     "start": "vite start",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "tsc": "tsc -p tsconfig.json --noEmit",
     "swagger-typescript-api": "swagger-typescript-api -p https://www.knu-haedal.com/api/v3/api-docs -r -o ./src/models --modular -d --extract-request-body --extract-response-body --extract-response-error --axios",
     "prepare": "husky"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "npx prettier --write",
-      "npx eslint --cache --fix",
-      "npx tsc -p tsconfig.json --noEmit"
+      "npm run format",
+      "npm run lint:fix",
+      "npm run tsc"
     ]
   },
   "dependencies": {

--- a/frontend/src/pages/activity-board/create-board/components/form/Form.tsx
+++ b/frontend/src/pages/activity-board/create-board/components/form/Form.tsx
@@ -85,6 +85,7 @@ export const CreateBoardForm = ({ activityId }: CreateBoardFromProps) => {
             <Textarea
               value={field.value}
               onChange={field.onChange}
+              className="h-24"
               placeholder="게시판 소개글을 작성해주세요"
             />
           )}

--- a/frontend/src/pages/activity-board/create-board/components/form/form-field/FormField.tsx
+++ b/frontend/src/pages/activity-board/create-board/components/form/form-field/FormField.tsx
@@ -29,7 +29,7 @@ export const BoardFormField = ({
       render={({ field }) => (
         <FormItem className="flex flex-col">
           <div className="flex flex-col md:flex-row md:items-start">
-            <Label className="w-40 text-md">{label}</Label>
+            <Label className="text-md w-40">{label}</Label>
             <FormControl>{children(field)}</FormControl>
           </div>
           <div className="flex justify-end">

--- a/frontend/src/pages/activity-board/create-board/components/form/form-field/FormField.tsx
+++ b/frontend/src/pages/activity-board/create-board/components/form/form-field/FormField.tsx
@@ -28,8 +28,8 @@ export const BoardFormField = ({
       name={name}
       render={({ field }) => (
         <FormItem className="flex flex-col">
-          <div className="flex flex-col md:flex-row md:items-center">
-            <Label className="text-md w-40">{label}</Label>
+          <div className="flex flex-col md:flex-row md:items-start">
+            <Label className="w-40 text-md">{label}</Label>
             <FormControl>{children(field)}</FormControl>
           </div>
           <div className="flex justify-end">

--- a/frontend/src/pages/activity-board/edit-board/_components/form/Form.tsx
+++ b/frontend/src/pages/activity-board/edit-board/_components/form/Form.tsx
@@ -90,7 +90,7 @@ export const EditBoardForm = ({
   return (
     <Form {...form}>
       <form
-        className="flex w-full max-w-lg flex-col gap-4"
+        className="flex flex-col gap-4 w-full max-w-lg"
         onSubmit={form.handleSubmit(onSubmit)}
       >
         <BoardFormField name="boardName" label="게시판 제목">
@@ -105,6 +105,7 @@ export const EditBoardForm = ({
         <BoardFormField name="boardIntro" label="게시판 소개">
           {(field) => (
             <Textarea
+              className="h-24"
               value={field.value}
               onChange={field.onChange}
               placeholder="게시판 소개글을 작성해주세요"
@@ -121,7 +122,7 @@ export const EditBoardForm = ({
             />
           )}
         </BoardFormField>
-        <div className="flex justify-end gap-2 pt-2">
+        <div className="flex gap-2 justify-end pt-2">
           <Button
             type="button"
             variant="outline"

--- a/frontend/src/pages/activity-board/edit-board/_components/form/Form.tsx
+++ b/frontend/src/pages/activity-board/edit-board/_components/form/Form.tsx
@@ -90,7 +90,7 @@ export const EditBoardForm = ({
   return (
     <Form {...form}>
       <form
-        className="flex flex-col gap-4 w-full max-w-lg"
+        className="flex w-full max-w-lg flex-col gap-4"
         onSubmit={form.handleSubmit(onSubmit)}
       >
         <BoardFormField name="boardName" label="게시판 제목">
@@ -122,7 +122,7 @@ export const EditBoardForm = ({
             />
           )}
         </BoardFormField>
-        <div className="flex gap-2 justify-end pt-2">
+        <div className="flex justify-end gap-2 pt-2">
           <Button
             type="button"
             variant="outline"

--- a/frontend/src/service/schema/board.ts
+++ b/frontend/src/service/schema/board.ts
@@ -4,10 +4,10 @@ export const CreateBoardSchema = z.object({
   boardName: z
     .string()
     .min(1, { message: '게시판 제목을 입력해주세요.' })
-    .max(15, { message: '게시판 제목은 15자 이내여야 합니다.' }),
+    .max(30, { message: '게시판 제목은 30자 이내여야 합니다.' }),
   boardIntro: z
     .string()
-    .max(50, { message: '게시판 소개글은 50자 이내여야 합니다.' }),
+    .max(255, { message: '게시판 소개글은 255자 이내여야 합니다.' }),
   file: z
     .instanceof(File)
     .refine((f) => f.size < 5000000, {
@@ -27,10 +27,10 @@ export const UpdateBoardSchema = z.object({
   boardName: z
     .string()
     .min(1, { message: '게시판 제목을 입력해주세요.' })
-    .max(15, { message: '게시판 제목은 15자 이내여야 합니다.' }),
+    .max(30, { message: '게시판 제목은 30자 이내여야 합니다.' }),
   boardIntro: z
     .string()
-    .max(50, { message: '게시판 소개글은 50자 이내여야 합니다.' }),
+    .max(255, { message: '게시판 소개글은 255자 이내여야 합니다.' }),
   participants: z
     .string()
     .array()


### PR DESCRIPTION
### 📝 상세 내용
## AS-IS

- 게시판 제목 : 15자 제한
- 게시판 소개 글 : 50자 제한

```tsx
export const CreateBoardSchema = z.object({
...
  boardName: z
    .max(15, { message: '게시판 제목은 15자 이내여야 합니다.' }),
  boardIntro: z
    .max(50, { message: '게시판 소개글은 50자 이내여야 합니다.' }),
...
})

export const UpdateBoardSchema = z.object({
...
  boardName: z
    .max(15, { message: '게시판 제목은 15자 이내여야 합니다.' }),
  boardIntro: z
    .max(50, { message: '게시판 소개글은 50자 이내여야 합니다.' }),
...
})
```

<img width="1552" height="987" alt="image" src="https://github.com/user-attachments/assets/f64a4c25-8307-48e5-a956-f71d0098530a" />

## TO-BE

- 게시판 제목 : 30자 제한
- 게시판 소개글 255자 제한

```tsx
export const CreateBoardSchema = z.object({
...
  boardName: z
    .max(30, { message: '게시판 제목은 30자 이내여야 합니다.' }),
  boardIntro: z
    .max(255, { message: '게시판 소개글은 255자 이내여야 합니다.' }),
...
})

export const UpdateBoardSchema = z.object({
...
  boardName: z
    .max(30, { message: '게시판 제목은 30자 이내여야 합니다.' }),
  boardIntro: z
    .max(255, { message: '게시판 소개글은 255자 이내여야 합니다.' }),
...
})
```

게시판 소개 field의 글자수 제한이 늘어남에 따라 textarea의 높이를 조금 더 늘렸습니다.

<img width="1417" height="987" alt="image" src="https://github.com/user-attachments/assets/bd27ab7a-acd6-492b-9b56-225dfe8f06a0" />

<img width="1417" height="987" alt="image" src="https://github.com/user-attachments/assets/bc8b7a0f-c260-4a7e-bcd7-b3d6e93c6d8b" />

## Husky 스크립트 수정
포맷팅 관련 수정이 제대로 동작하지 않는 것 같아 스크립트를 수정하였습니다.

https://github.com/hanghae-plus/front_6th_chapter4-1/blob/main/.husky/pre-commit
### #️⃣ 이슈 번호
- #156


### 🔗 참고 자료
x

### 📷 스크린샷(선택)
위 이미지 참고
