### PR TITLE
Fix: 2025 2학기 모집 마감 타이머, 모집 일정, 제출 링크 수정

### DIFF
--- a/frontend/src/pages/recruit/components/countdown-timer/CountdownTimer.tsx
+++ b/frontend/src/pages/recruit/components/countdown-timer/CountdownTimer.tsx
@@ -3,7 +3,12 @@ import { useEffect, useMemo, useState } from 'react'
 import { getDateDistance } from '@toss/date'
 
 export const CountdownTimer = () => {
-  const endDate = useMemo(() => new Date('2025-03-03T15:00:00Z'), [])
+  /**
+   * 모집 마감 타이머
+   *
+   * @todo 새 학기 시작 시 모집 마감 시간 교체
+   */
+  const endDate = useMemo(() => new Date('2025-09-05T23:59:59+09:00'), [])
 
   const [distance, setDistance] = useState(getDateDistance(new Date(), endDate))
 

--- a/frontend/src/pages/recruit/components/link-button/LinkButton.tsx
+++ b/frontend/src/pages/recruit/components/link-button/LinkButton.tsx
@@ -11,7 +11,7 @@ interface RecruitLinkButtonProps {
 export const RecruitLinkButton = ({ className }: RecruitLinkButtonProps) => {
   const handleClick = () => {
     window.location.href =
-      'https://docs.google.com/forms/d/e/1FAIpQLSdhvW34Cscw1XceELYSccDKgBeAOw26D7wviNw9hsC3TMCYvw/viewform'
+      'https://docs.google.com/forms/d/e/1FAIpQLScdj0yHEl91sTmzIWjAGWj87AiAItrAoCC4xrO_IEzKk7PWKQ/viewform'
   }
 
   return (

--- a/frontend/src/pages/recruit/components/process/Process.tsx
+++ b/frontend/src/pages/recruit/components/process/Process.tsx
@@ -31,18 +31,22 @@ export const RecruitProcess = () => {
 const RECRUIT_PROCESS = [
   {
     title: '서류접수',
-    detail: '02.26.(화) ~ 03.03.(월)',
+    detail: '08.30.(토) ~ 09.05.(금)',
   },
   {
     title: '서류 발표',
-    detail: '03.05.(수)',
+    detail: '09.07.(일)',
   },
   {
     title: '오프라인 면접',
-    detail: '03.06.(목) ~ 03.09.(일)',
+    detail: '09.08.(월) ~ 09.10.(수)',
   },
   {
     title: '최종 발표',
-    detail: '03.11.(화) ~ 03.12.(수)',
+    detail: '09.12.(금)',
+  },
+  {
+    title: '신규 부원 OT',
+    detail: '09.16.(화)',
   },
 ]

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -21,10 +21,12 @@ import {
   NotFoundPage,
   NoticePage,
   NoticePostPage,
+  RecruitPage,
   RedirectActivityPage,
   SignupPage,
 } from '@/pages'
-import RecruitCommingSoonPage from '@/pages/recruit/CommingSoonPage'
+
+// import RecruitCommingSoonPage from '@/pages/recruit/CommingSoonPage'
 
 import {
   ActivityRoute,
@@ -101,7 +103,8 @@ export const Router = () => {
         </Route>
         <Route path="/" element={<MainPage />} />
         <Route path="/recruit">
-          <Route index element={<RecruitCommingSoonPage />} />
+          {/* <Route index element={<RecruitCommingSoonPage />} /> */}
+          <Route index element={<RecruitPage />} />
         </Route>
         <Route path="/*" element={<NotFoundPage />} />
       </Routes>


### PR DESCRIPTION
### 📝 상세 내용

- [x] /recruit를 CommingSoonPage 에서 RecruitPage 로 변경
- [x] 모집 마감 타이머 25.09.05. 23:59 분으로 수정
- [x] 모집 일정 수정
- [x] 모집 제출 링크 수정

### #️⃣ 이슈 번호

- close #167 

### 🔗 참고 자료



### 📷 스크린샷(선택)


<img width="525" height="434" alt="image" src="https://github.com/user-attachments/assets/979f3d11-e028-4881-ac1b-7abea9b59d39" />
<img width="514" height="211" alt="image" src="https://github.com/user-attachments/assets/bc84743e-d0e0-4576-8847-2d1ac5cb5dfe" />
