### PR TITLE
Fix: 2025 하반기 모집 완료 페이지로 수정

### DIFF
--- a/frontend/src/pages/recruit/components/recruit-closed-hero/RecruitClosedHero.tsx
+++ b/frontend/src/pages/recruit/components/recruit-closed-hero/RecruitClosedHero.tsx
@@ -14,8 +14,8 @@ export const RecruitClosedHero = () => {
           </div>
         </div>
         <div className="flex flex-col gap-1.5 text-sm sm:text-base">
-          <div>2025년 상반기 모집이 완료되었습니다</div>
-          <div>다음 모집은 2025년 8월 30일에 예정되어 있습니다</div>
+          <div>2025년 하반기 모집이 완료되었습니다</div>
+          <div>다음 모집은 2026년 상반기에 예정되어 있습니다</div>
         </div>
         <div className="absolute -bottom-10 right-0 z-30 sm:-bottom-12 md:-bottom-16 lg:-bottom-20">
           <img

--- a/frontend/src/pages/recruit/components/track/Track.tsx
+++ b/frontend/src/pages/recruit/components/track/Track.tsx
@@ -77,9 +77,6 @@ export const RecruitTrack = () => {
               </div>
             )}
           </Card>
-          <div className="py-2 text-center text-base font-normal text-zinc-400 sm:text-lg">
-            ※ 소모임은 학기 초 개설 예정입니다.
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/Router.tsx
+++ b/frontend/src/routes/Router.tsx
@@ -7,6 +7,7 @@ import {
   ActivityPostPage,
   AdminMemberPage,
   AdminSemesterPage,
+  CommingSoonPage,
   CreateActivityPostPage,
   CreateBoardPage,
   CreateNoticePostPage,
@@ -21,12 +22,10 @@ import {
   NotFoundPage,
   NoticePage,
   NoticePostPage,
-  RecruitPage,
+  // RecruitPage,
   RedirectActivityPage,
   SignupPage,
 } from '@/pages'
-
-// import RecruitCommingSoonPage from '@/pages/recruit/CommingSoonPage'
 
 import {
   ActivityRoute,
@@ -103,8 +102,8 @@ export const Router = () => {
         </Route>
         <Route path="/" element={<MainPage />} />
         <Route path="/recruit">
-          {/* <Route index element={<RecruitCommingSoonPage />} /> */}
-          <Route index element={<RecruitPage />} />
+          <Route index element={<CommingSoonPage />} />
+          {/* <Route index element={<RecruitPage />} /> */}
         </Route>
         <Route path="/*" element={<NotFoundPage />} />
       </Routes>


### PR DESCRIPTION
### 📝 상세 내용

- /recruit에 접속하면 비모집 상태로 페이지 UI를 수정했습니다.
- 운영진의 요구에 따라, 모집 페이지 중 `※ 소모임은 학기 초 개설 예정입니다.`을 삭제했습니다.

### #️⃣ 이슈 번호

- close #173 


### 🔗 참고 자료



### 📷 스크린샷(선택)


