### PR TITLE
feat: 아키텍처 다이어그램 스킬 및 가이드 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+language: "ko-KR" # 리뷰 언어 설정
+
+reviews:
+  related_issues: false # 관련 이슈/PR 자동 링크
+  suggested_labels: false # 레이블 자동 제안/적용 (수동으로 관리)
+  suggested_reviewers: false # 리뷰어 추천/자동 할당 (수동으로 지정)

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,3 @@ next-env.d.ts
 
 # api docs
 /src/models
-
-# claude
-.claude/

--- a/frontend/.claude/skills/architecture-diagram/SKILL.md
+++ b/frontend/.claude/skills/architecture-diagram/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: architecture-diagram
+description: Verify and update the frontend architecture HTML documents and Mermaid diagrams when the user invokes /architecture-diagram or requests architecture-diagram validation or maintenance. Use after changes to routes, route guards, state stores, React Query, API configuration, or application layer boundaries.
+---
+
+# Architecture Diagram
+
+Keep the architecture guide accurate. Treat source code as the authority; do not infer undocumented policy.
+
+## Required reading
+
+Read `frontend/AGENTS.md` and the relevant files under `frontend/docs/architecture/` first. Then inspect only the source relevant to the request:
+
+- Routes or access control: `src/routes/Router.tsx` and applicable files in `src/routes/custom-route/`.
+- State or caching: `src/store/`, `src/lib/query-client.tsx`, and affected API modules in `src/service/api/`.
+- HTTP or authentication: `src/service/config/`, `src/lib/axios-instance.ts`, and affected auth APIs.
+- Layer ownership: `src/main.tsx`, `src/App.tsx`, and affected `pages`, `components`, `service`, `store`, `lib`, `types`, `utils`, `constant`, and `data` paths.
+- Input and mutation handling: affected `service/schema/` files plus representative form and mutation call sites.
+- Loading and errors: affected Suspense routes, error boundaries, and toast handlers.
+
+## Workflow
+
+1. Classify the request as layer ownership, navigation/access, data/state, or a combination.
+2. Compare relevant code with the matching HTML document and Mermaid diagram, including actual component-to-service/store imports rather than assuming a strictly page-owned data layer.
+3. Verify the complete feature path when applicable: form state and Zod schema, API module and generated model, mutation result, cache invalidation, navigation, toast, loading, and error boundary.
+4. Verify route redirects, NotFound handling, and the role hierarchy used by access guards.
+5. Update only statements, links, nodes, or edges disproven by the code. Preserve correct content. Label intended behavior or a known risk when an error path does not guarantee the documented outcome.
+6. Decide whether the change belongs in `overview`, `navigation-and-access`, or `data-and-state`. Propose a domain document only when those common documents cannot clearly explain an independent route, API, state, and permission flow.
+7. Open every changed HTML file in a browser. Confirm relative links resolve, Mermaid renders an SVG, and the browser console has no document or Mermaid errors.
+8. Report changed files, verified-but-unchanged files, and any policy that needs human confirmation.
+
+## Document boundaries
+
+- Put directory responsibilities and dependency direction in `overview/index.html`.
+- Put component dependency rules, global providers, and shared support directories in `overview/index.html`.
+- Put routes, layouts, redirects, NotFound handling, role hierarchy, and role checks in `navigation-and-access/index.html`.
+- Put API clients, generated contracts, Zod schemas, React Query keys and invalidation, Zustand persistence, token handling, forms, loading, errors, and mutation side effects in `data-and-state/index.html`.
+- Keep the root index limited to navigation and maintenance rules.
+
+## Validation rules
+
+- Keep Mermaid on the pinned CDN version and initialize it with `securityLevel: 'strict'`.
+- Verify Mermaid nodes and edges against code, not against an earlier diagram.
+- Do not describe a cleanup or retry outcome as guaranteed when an awaited error path can fail before the cleanup runs.
+- Do not modify generated files under `src/service/model/` or `src/lib/http-client.ts`.
+- If browser validation cannot run, state why and identify the unverified files.

--- a/frontend/.claude/skills/architecture-diagram/SKILL.md
+++ b/frontend/.claude/skills/architecture-diagram/SKILL.md
@@ -9,7 +9,7 @@ Keep the architecture guide accurate. Treat source code as the authority; do not
 
 ## Required reading
 
-Read `frontend/AGENTS.md` and the relevant files under `frontend/docs/architecture/` first. Then inspect only the source relevant to the request:
+Read `AGENTS.md` and the relevant files under `docs/architecture/` first. Then inspect only the source relevant to the request:
 
 - Routes or access control: `src/routes/Router.tsx` and applicable files in `src/routes/custom-route/`.
 - State or caching: `src/store/`, `src/lib/query-client.tsx`, and affected API modules in `src/service/api/`.

--- a/frontend/.codex/skills/architecture-diagram/SKILL.md
+++ b/frontend/.codex/skills/architecture-diagram/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: architecture-diagram
+description: Verify and update the frontend architecture HTML documents and Mermaid diagrams when the user explicitly invokes $architecture-diagram or requests architecture-diagram validation or maintenance. Use after changes to routes, route guards, state stores, React Query, API configuration, or application layer boundaries.
+---
+
+# Architecture Diagram
+
+Use this skill to keep the architecture guide accurate. Treat source code as the authority; do not infer undocumented policy.
+
+## Required reading
+
+Read `frontend/AGENTS.md` and the relevant files under `frontend/docs/architecture/` first. Then inspect only the source relevant to the request:
+
+- Routes or access control: `src/routes/Router.tsx` and applicable files in `src/routes/custom-route/`.
+- State or caching: `src/store/`, `src/lib/query-client.tsx`, and affected API modules in `src/service/api/`.
+- HTTP or authentication: `src/service/config/`, `src/lib/axios-instance.ts`, and affected auth APIs.
+- Layer ownership: `src/main.tsx`, `src/App.tsx`, and affected `pages`, `components`, `service`, `store`, `lib`, `types`, `utils`, `constant`, and `data` paths.
+- Input and mutation handling: affected `service/schema/` files plus representative form and mutation call sites.
+- Loading and errors: affected Suspense routes, error boundaries, and toast handlers.
+
+## Workflow
+
+1. Classify the request as layer ownership, navigation/access, data/state, or a combination.
+2. Compare relevant code with the matching HTML document and Mermaid diagram, including actual component-to-service/store imports rather than assuming a strictly page-owned data layer.
+3. Verify the complete feature path when applicable: form state and Zod schema, API module and generated model, mutation result, cache invalidation, navigation, toast, loading, and error boundary.
+4. Verify route redirects, NotFound handling, and the role hierarchy used by access guards.
+5. Update only statements, links, nodes, or edges disproven by the code. Preserve correct content. Label intended behavior or a known risk when an error path does not guarantee the documented outcome.
+6. Decide whether the change belongs in `overview`, `navigation-and-access`, or `data-and-state`. Propose a domain document only when those common documents cannot clearly explain an independent route, API, state, and permission flow.
+7. Open every changed HTML file in a browser. Confirm relative links resolve, Mermaid renders an SVG, and the browser console has no document or Mermaid errors.
+8. Report changed files, verified-but-unchanged files, and any policy that needs human confirmation.
+
+## Document boundaries
+
+- Put directory responsibilities and dependency direction in `overview/index.html`.
+- Put component dependency rules, global providers, and shared support directories in `overview/index.html`.
+- Put routes, layouts, redirects, NotFound handling, role hierarchy, and role checks in `navigation-and-access/index.html`.
+- Put API clients, generated contracts, Zod schemas, React Query keys and invalidation, Zustand persistence, token handling, forms, loading, errors, and mutation side effects in `data-and-state/index.html`.
+- Keep the root index limited to navigation and maintenance rules.
+
+## Validation rules
+
+- Keep Mermaid on the pinned CDN version and initialize it with `securityLevel: 'strict'`.
+- Verify Mermaid nodes and edges against code, not against an earlier diagram.
+- Do not describe a cleanup or retry outcome as guaranteed when an awaited error path can fail before the cleanup runs.
+- Do not modify generated files under `src/service/model/` or `src/lib/http-client.ts`.
+- If browser validation cannot run, state why and identify the unverified files.

--- a/frontend/.codex/skills/architecture-diagram/SKILL.md
+++ b/frontend/.codex/skills/architecture-diagram/SKILL.md
@@ -9,7 +9,7 @@ Use this skill to keep the architecture guide accurate. Treat source code as the
 
 ## Required reading
 
-Read `frontend/AGENTS.md` and the relevant files under `frontend/docs/architecture/` first. Then inspect only the source relevant to the request:
+Read `AGENTS.md` and the relevant files under `docs/architecture/` first. Then inspect only the source relevant to the request:
 
 - Routes or access control: `src/routes/Router.tsx` and applicable files in `src/routes/custom-route/`.
 - State or caching: `src/store/`, `src/lib/query-client.tsx`, and affected API modules in `src/service/api/`.

--- a/frontend/.codex/skills/architecture-diagram/agents/openai.yaml
+++ b/frontend/.codex/skills/architecture-diagram/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Architecture Diagram"
+  short_description: "Verify and update architecture diagrams"
+  default_prompt: "Use $architecture-diagram to verify and update the frontend architecture diagrams."

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -43,7 +43,7 @@ git switch -c feature/<이슈번호>-<키워드>
 ```
 
 - `main`에는 직접 커밋하거나 push하지 않습니다. 작업 커밋과 push는 feature 브랜치에서만 수행합니다.
-- 커밋 메시지는 `type: 한국어 설명` 형식으로 작성하고, 설명에는 변경 내용의 목적과 의도를 간결하게 담습니다. Husky의 `commit-msg` 훅은 `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` type과 한글 설명을 자동으로 검증합니다.
+- 커밋 제목은 `type: 한국어 설명` 형식으로 작성하고, 변경 내용을 간결하게 요약합니다. 의도·맥락·선택 이유를 설명할 필요가 있으면 제목 아래를 빈 줄로 구분한 본문에 문장으로 작성할 수 있습니다. Husky의 `commit-msg` 훅은 제목 형식을 자동으로 검증합니다.
 - Husky의 `pre-commit` 훅은 lint-staged를 실행해 스테이징된 JavaScript·TypeScript 파일을 포맷, 린트, 타입 검사합니다.
 - 커밋은 이슈의 TODO와 대응하게 만들고, 모든 TODO를 완료한 뒤 PR을 엽니다.
 - PR은 origin의 feature 브랜치에서 upstream의 `main`을 대상으로 만듭니다. 제목은 `<type>: <설명>` 형식이며, `type`은 `feature`, `fix`, `chore` 중 하나를 사용합니다.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,7 +1,11 @@
 # 개발 가이드
 
-## AI 개발 보조
+## Claude Code, Codex 사용 시 참고
 
 Codex와 Claude Code는 반드시 `frontend/`에서 시작해 프론트엔드 전용 지침을 읽습니다. 공통 작업 규칙은 [AGENTS.md](./AGENTS.md)를 참고하세요.
 
 개인별 Claude Code 규칙이 필요하면 `frontend/CLAUDE.local.md`를 만들어 사용할 수 있습니다. 이 파일은 Git에서 제외되므로 개인 지침을 커밋하지 않습니다.
+
+## 아키텍처 문서
+
+프로젝트의 계층 구조, 라우팅·권한, 데이터·상태 흐름은 [아키텍처 가이드](./docs/architecture/index.html)에서 확인합니다. 해당 HTML 파일은 브라우저로 열어 확인할 수 있습니다. 프로젝트의 구조가 바뀌면 Codex에서는 `$architecture-diagram`, Claude Code에서는 `/architecture-diagram`으로 문서를 코드 기준으로 갱신합니다.

--- a/frontend/docs/architecture/data-and-state/index.html
+++ b/frontend/docs/architecture/data-and-state/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>데이터·상태 | 해달 프론트엔드 아키텍처</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../index.html">해달 프론트엔드 아키텍처</a>
+      <nav class="site-nav" aria-label="아키텍처 문서"><a href="../index.html">시작</a><a href="../overview/index.html">구조</a><a href="../navigation-and-access/index.html">화면·접근</a><a href="index.html" aria-current="page">데이터·상태</a></nav>
+    </header>
+    <main>
+      <h1>데이터와 상태 관리</h1>
+      <p class="lede">서버에서 온 데이터는 React Query와 도메인 API 모듈로 관리하고, 인증 토큰과 내 정보처럼 브라우저에 유지해야 하는 클라이언트 상태만 Zustand에 둡니다.</p>
+      <pre class="mermaid">
+flowchart LR
+  Form[react-hook-form] --> Schema[service/schema: Zod 검증]
+  Schema --> UI[페이지·기능 컴포넌트]
+  UI --> Query[React Query: useQuery·useMutation]
+  UI --> Store[Zustand persist]
+  Query --> API[service/api 도메인 모듈]
+  API --> Public[BACKEND_API]
+  API --> Private[AUTHORIZATION_API]
+  Private --> Token[access-token store]
+  Private --> Interceptor[401 인터셉터]
+  Interceptor --> Reissue[reissue API]
+  Reissue --> Token
+  Interceptor --> Logout[logout API·my-info 초기화]
+  API --> Generated[service/model 생성 클라이언트]
+  Query --> Cache[QueryClient 캐시]
+  Query --> Invalidate[관련 Query 키 무효화]
+  Invalidate --> Feedback[toast와 화면 이동]
+      </pre>
+      <h2>상태의 위치</h2>
+      <table>
+        <thead><tr><th>종류</th><th>현재 구현</th><th>추가 기준</th></tr></thead>
+        <tbody>
+          <tr><td>서버 상태</td><td><code>service/api</code>의 <code>queryOptions</code>, 페이지·컴포넌트의 <code>useQuery</code>/<code>useMutation</code></td><td>조회에는 도메인 Query 옵션과 안정적인 Query 키를 만들고, 변경 성공 뒤 관련 <code>all()</code> 또는 목록 키를 무효화합니다.</td></tr>
+          <tr><td>클라이언트 영속 상태</td><td><code>useAuthStore</code>: access token, <code>useMyInfoStore</code>: 사용자 ID·이름·역할·프로필 이미지</td><td>서버 응답 캐시가 아닌 세션·UI 전역 상태이며 새로고침 뒤에도 필요한 값만 추가합니다.</td></tr>
+          <tr><td>Query 기본 정책</td><td>재시도 1회, stale time 3분, mount/window focus 재조회 비활성화, 오류 throw</td><td>도메인별 요구가 다를 때만 호출 지점에서 명시적으로 재정의합니다.</td></tr>
+        </tbody>
+      </table>
+      <h2>새 API·데이터 변경 흐름</h2>
+      <ol>
+        <li>입력이 있으면 <code>service/schema</code>에 Zod 스키마와 폼 타입을 두고 <code>react-hook-form</code>에서 사용합니다.</li>
+        <li><code>service/api</code>에 생성 클라이언트를 감싼 API 함수와 조회용 Query 옵션·키를 추가합니다.</li>
+        <li>mutation 성공 뒤 영향받는 <code>all()</code> 또는 목록 키를 <code>queryClient.invalidateQueries</code>로 무효화합니다.</li>
+        <li>필요한 경우 toast로 결과를 알리고, 생성·수정 후에는 목적 화면으로 이동합니다.</li>
+      </ol>
+      <h2>로딩과 오류 경계</h2>
+      <ul>
+        <li><code>useSuspenseQuery</code>를 쓰는 화면은 상위 <code>Suspense</code>와 <code>ErrorBoundary</code>가 있는지 확인합니다.</li>
+        <li>공지·회원의 <code>SuspenseRoute</code>는 공통 Spinner와 기본 오류 화면을, 활동의 <code>ActivityRoute</code>는 활동 전용 fallback을 제공합니다.</li>
+        <li>mutation과 폼 오류는 호출 지점에서 toast·필드 오류로 처리합니다. 새 mutation은 성공·실패 피드백을 함께 설계합니다.</li>
+      </ul>
+      <h2>API와 인증 흐름</h2>
+      <ul>
+        <li>공개 요청은 <code>BACKEND_API</code>, 인증이 필요한 요청은 <code>AUTHORIZATION_API</code>를 사용합니다.</li>
+        <li>인증 인스턴스는 Zustand의 access token을 <code>Authorization</code> 헤더에 붙이고 쿠키를 포함합니다.</li>
+        <li>401 응답은 단일 토큰 재발급 요청으로 묶고, 성공하면 대기 요청을 새 토큰으로 재시도합니다.</li>
+        <li>재발급 실패 시 로그아웃 API를 시도한 뒤 내 정보 상태 초기화와 알림을 수행하도록 구현되어 있습니다. 로그아웃 요청 자체가 실패하면 해당 후속 정리는 보장되지 않는 현재 위험입니다.</li>
+      </ul>
+      <aside class="notice"><strong>주의:</strong> <code>src/service/config/</code>의 API 기본 URL, 인증 인터셉터, 쿠키·토큰 처리는 서비스 계약과 보안에 영향을 줍니다. 변경 전 명시적인 검토가 필요합니다.</aside>
+      <p class="footer"><a href="../navigation-and-access/index.html">이전: 화면·접근</a> · <a href="../index.html">시작으로</a></p>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, securityLevel: 'strict', theme: 'neutral' });</script>
+  </body>
+</html>

--- a/frontend/docs/architecture/index.html
+++ b/frontend/docs/architecture/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>해달 프론트엔드 아키텍처</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="index.html">해달 프론트엔드 아키텍처</a>
+      <nav class="site-nav" aria-label="아키텍처 문서">
+        <a href="index.html" aria-current="page">시작</a>
+        <a href="overview/index.html">구조</a>
+        <a href="navigation-and-access/index.html">화면·접근</a>
+        <a href="data-and-state/index.html">데이터·상태</a>
+      </nav>
+    </header>
+    <main>
+      <h1>기능을 안전하게 추가하기 위한 구조 안내</h1>
+      <p class="lede">새 기능을 어느 계층에 두고, 어떤 라우트·권한·데이터 흐름을 함께 확인해야 하는지 안내합니다.</p>
+      <div class="card-grid">
+        <article class="card"><h2><a href="overview/index.html">구조</a></h2><p>페이지, 공통 컴포넌트, 서비스, 상태 계층의 책임과 의존 방향을 확인합니다.</p></article>
+        <article class="card"><h2><a href="navigation-and-access/index.html">화면·접근</a></h2><p>새 화면의 URL, 레이아웃, 로그인·역할 조건을 결정합니다.</p></article>
+        <article class="card"><h2><a href="data-and-state/index.html">데이터·상태</a></h2><p>API 호출, 캐시 무효화, 클라이언트 상태와 인증 흐름을 추가합니다.</p></article>
+      </div>
+      <h2>갱신 기준</h2>
+      <ul>
+        <li>계층 책임이나 디렉터리 경계가 바뀌면 <a href="overview/index.html">구조</a>를 갱신합니다.</li>
+        <li>화면·라우트·레이아웃·가드·역할 조건이 바뀌면 <a href="navigation-and-access/index.html">화면·접근</a>을 갱신합니다.</li>
+        <li>API·React Query·Zustand·인증 요청 흐름이 바뀌면 <a href="data-and-state/index.html">데이터·상태</a>를 갱신합니다.</li>
+      </ul>
+      <aside class="notice"><strong>검증:</strong> 다이어그램 갱신이나 구조 검증이 필요하면 <code>$architecture-diagram</code>을 요청합니다. 스킬은 코드와 문서를 대조해 필요한 파일만 수정합니다.</aside>
+      <p class="footer">릴리스마다 문서 최신성을 점검합니다. 이 문서는 저장소에서 직접 브라우저로 열람하는 용도입니다.</p>
+    </main>
+  </body>
+</html>

--- a/frontend/docs/architecture/navigation-and-access/index.html
+++ b/frontend/docs/architecture/navigation-and-access/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>화면·접근 | 해달 프론트엔드 아키텍처</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../index.html">해달 프론트엔드 아키텍처</a>
+      <nav class="site-nav" aria-label="아키텍처 문서"><a href="../index.html">시작</a><a href="../overview/index.html">구조</a><a href="index.html" aria-current="page">화면·접근</a><a href="../data-and-state/index.html">데이터·상태</a></nav>
+    </header>
+    <main>
+      <h1>화면 진입과 접근 제어</h1>
+      <p class="lede">모든 라우트는 <code>src/routes/Router.tsx</code>에 선언합니다. 새 화면은 URL과 함께 어떤 레이아웃, 로딩 경계, 인증·역할 가드를 거치는지 결정해야 합니다.</p>
+      <pre class="mermaid">
+flowchart TD
+  Root["/"] --> MainPage[MainPage]
+  Root --> Recruit["/recruit · RecruitPage"]
+  Root --> Auth["/auth · AuthRoute"]
+  Auth --> Login[login]
+  Auth --> Signup[signup]
+  Auth --> Find[find]
+  Root --> Main[MainRoute + MainLayout]
+  Main --> Activity["/activity · ActivityRoute"]
+  Main --> Notice["/notice · SuspenseRoute"]
+  Main --> Member["/member · SuspenseRoute"]
+  Main --> MyPage["/mypage · MyPageRoute"]
+  Root --> Admin["/admin · AdminRoute + MainLayout"]
+  Admin --> AdminMember[member]
+  Admin --> AdminSemester[semester]
+  Activity --> Board[boards와 posts]
+  Activity --> Redirect[":semesterId 리다이렉트"]
+  Notice --> AdminNotice[AdminNoticeRoute: 작성·수정]
+  Root --> NotFound["/* · NotFoundPage"]
+      </pre>
+      <h2>가드와 레이아웃</h2>
+      <table>
+        <thead><tr><th>경계</th><th>적용 대상</th><th>동작</th></tr></thead>
+        <tbody>
+          <tr><td><code>MainRoute</code></td><td>활동, 공지, 회원, 마이페이지</td><td><code>MainLayout</code>과 공통 콘텐츠 여백을 제공합니다.</td></tr>
+          <tr><td><code>AuthRoute</code></td><td><code>/auth/*</code></td><td>로그인 사용자를 <code>/</code>로 이동시키고 인증 화면 레이아웃을 제공합니다.</td></tr>
+          <tr><td><code>MyPageRoute</code></td><td><code>/mypage</code></td><td>access token이 없으면 <code>/</code>로 이동하고, 있으면 Suspense 경계를 제공합니다.</td></tr>
+          <tr><td><code>AdminRoute</code></td><td><code>/admin/*</code></td><td><code>ROLE_ADMIN</code> 이상만 관리 사이드바와 화면에 접근합니다.</td></tr>
+          <tr><td><code>AdminNoticeRoute</code></td><td>공지 작성·수정</td><td><code>ROLE_ADMIN</code> 미만이면 <code>/notice</code>로 이동합니다.</td></tr>
+          <tr><td><code>AdminBoardRoute</code></td><td>활동 게시판 수정</td><td><code>ROLE_TEAM_LEADER</code> 미만이면 이전 화면으로 이동합니다.</td></tr>
+          <tr><td><code>AdminActivityPostRoute</code></td><td>활동 게시글 수정</td><td><code>ROLE_MEMBER</code> 미만이면 이전 화면으로 이동합니다.</td></tr>
+        </tbody>
+      </table>
+      <h2>역할과 리다이렉트 기준</h2>
+      <table>
+        <thead><tr><th>역할 순서</th><th>적용 방식</th><th>리다이렉트 예시</th></tr></thead>
+        <tbody>
+          <tr><td><code>ROLE_WEB_MASTER</code> → <code>ROLE_ADMIN</code> → <code>ROLE_TEAM_LEADER</code> → <code>ROLE_MEMBER</code></td><td><code>isRoleAboveOrEqual</code>은 대상 역할과 같거나 상위 역할을 허용합니다.</td><td>관리자·공지 가드는 지정 경로로 이동하고, 활동 수정 가드는 이전 화면으로 이동합니다.</td></tr>
+          <tr><td>인증되지 않은 사용자</td><td><code>MyPageRoute</code>는 access token을 확인합니다.</td><td><code>/mypage</code> 접근 시 <code>/</code>로 이동합니다.</td></tr>
+          <tr><td>알 수 없는 경로</td><td>최상위 와일드카드 라우트가 처리합니다.</td><td><code>NotFoundPage</code>를 렌더링합니다.</td></tr>
+        </tbody>
+      </table>
+      <h2>새 화면 추가 체크</h2>
+      <ol>
+        <li><code>src/pages</code>에 화면을 두고 <code>src/pages/index.ts</code>에서 노출합니다.</li>
+        <li><code>Router.tsx</code>에 URL을 추가하고 상위 레이아웃과 가드를 선택합니다.</li>
+        <li>로그인 또는 역할이 필요하면 기존 가드가 조건과 리다이렉트 방식에 맞는지 확인합니다.</li>
+        <li>데이터 조회나 변경이 있으면 <a href="../data-and-state/index.html">데이터·상태</a>의 Query·상태 기준을 적용합니다.</li>
+      </ol>
+      <p class="footer"><a href="../overview/index.html">이전: 구조</a> · <a href="../data-and-state/index.html">다음: 데이터·상태</a></p>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, securityLevel: 'strict', theme: 'neutral' });</script>
+  </body>
+</html>

--- a/frontend/docs/architecture/overview/index.html
+++ b/frontend/docs/architecture/overview/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>구조 | 해달 프론트엔드 아키텍처</title>
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <a class="brand" href="../index.html">해달 프론트엔드 아키텍처</a>
+      <nav class="site-nav" aria-label="아키텍처 문서"><a href="../index.html">시작</a><a href="index.html" aria-current="page">구조</a><a href="../navigation-and-access/index.html">화면·접근</a><a href="../data-and-state/index.html">데이터·상태</a></nav>
+    </header>
+    <main>
+      <h1>구조와 의존 방향</h1>
+      <p class="lede">기능을 추가할 때는 화면에서 서비스와 상태 계층으로 내려가는 방향을 유지하고, 공통 UI와 도메인 기능 UI의 책임을 구분합니다.</p>
+      <pre class="mermaid">
+flowchart TD
+  Main[main.tsx: StrictMode와 전역 CSS] --> App[App.tsx]
+  App --> Provider[React Query Provider]
+  App --> Toaster[전역 Toaster]
+  Provider --> Router[Router와 route guards]
+  Router --> Pages[pages: 화면 단위 조합]
+  Pages --> Feature[components/feature: 도메인 UI]
+  Pages --> Common[components/common·ui: 재사용 UI]
+  Feature --> Service
+  Feature --> Store
+  Pages --> Service[service/api: API·query options]
+  Service --> Config[service/config: Axios 인스턴스·인터셉터]
+  Service --> Model[service/model: 생성된 API 모델]
+  Pages --> Store[store: 영속 클라이언트 상태]
+  Config --> Store
+      </pre>
+      <h2>계층별 책임</h2>
+      <table>
+        <thead><tr><th>영역</th><th>책임</th><th>새 기능을 추가할 때</th></tr></thead>
+        <tbody>
+          <tr><td><code>pages</code></td><td>라우트에 연결되는 화면과 화면 전용 조합</td><td>새 화면의 진입점과 화면 전용 하위 컴포넌트를 둡니다.</td></tr>
+          <tr><td><code>components/ui</code></td><td>Radix·CVA 기반의 디자인 시스템 프리미티브</td><td>Button, Input, Dialog처럼 조합 가능한 기본 제어 요소를 추가합니다.</td></tr>
+          <tr><td><code>components/common</code></td><td>앱 전반에서 재사용하는 의미 있는 조합 컴포넌트</td><td>Logo, LinkButton, Pagination처럼 UI 프리미티브를 조합한 앱 공통 패턴을 추가합니다.</td></tr>
+          <tr><td><code>components/feature</code></td><td>댓글, 게시글, 레이아웃 등 도메인 기능 UI</td><td>여러 페이지에서 공유되는 도메인 UI를 둡니다.</td></tr>
+          <tr><td><code>service/api</code></td><td>생성 API 클라이언트를 감싼 호출, Query 옵션, mutation용 함수</td><td>API 경계와 Query 키를 도메인 모듈에 추가합니다.</td></tr>
+          <tr><td><code>service/config</code></td><td>Axios 인스턴스와 인증 오류 처리</td><td>보안·계약 영향이 있으므로 명시적 검토 없이 변경하지 않습니다.</td></tr>
+          <tr><td><code>store</code></td><td>Zustand 기반 영속 클라이언트 상태</td><td>서버 캐시가 아닌 UI·세션 상태만 추가합니다.</td></tr>
+          <tr><td><code>lib</code></td><td>QueryClient, Axios 생성 등 인프라 보조 코드</td><td>여러 도메인이 공유하는 기반 동작에만 사용합니다.</td></tr>
+        </tbody>
+      </table>
+      <h2><code>components/common</code>과 <code>components/ui</code> 구분</h2>
+      <table>
+        <thead><tr><th>구분</th><th><code>components/ui</code></th><th><code>components/common</code></th></tr></thead>
+        <tbody>
+          <tr><td>목적</td><td>일관된 스타일·접근성을 제공하는 가장 작은 UI 단위</td><td>여러 화면에서 반복되는 앱 수준의 사용자 경험을 캡슐화</td></tr>
+          <tr><td>예시</td><td><code>Button</code>, <code>Input</code>, <code>Dialog</code>, <code>Select</code>, <code>Skeleton</code></td><td><code>Logo</code>, <code>LinkButton</code>, <code>PageBreadcrumb</code>, <code>PaginationButtons</code>, <code>ImageInput</code></td></tr>
+          <tr><td>허용 의존성</td><td>Radix, 스타일 유틸리티, 범용 props·접근성 상태</td><td><code>components/ui</code>, React Router 링크, 앱 공통 asset·유틸리티</td></tr>
+          <tr><td>두면 안 되는 것</td><td>라우트, 도메인 모델, API 호출, Zustand 스토어</td><td>특정 도메인의 API·스토어·권한 규칙</td></tr>
+          <tr><td>새 컴포넌트 판단</td><td>다른 기능에서도 독립적으로 조합할 수 있는 기본 제어 요소인가?</td><td>도메인과 무관하지만 앱에서 같은 흐름·표현이 반복되는가?</td></tr>
+        </tbody>
+      </table>
+      <h2>컴포넌트 의존성 기준</h2>
+      <table>
+        <thead><tr><th>영역</th><th>허용되는 의존성</th><th>피해야 할 의존성</th></tr></thead>
+        <tbody>
+          <tr><td><code>pages</code></td><td>라우트 파라미터, 화면 조합, feature/common UI, API·상태 조율</td><td>다른 페이지 구현의 직접 재사용</td></tr>
+          <tr><td><code>components/feature</code></td><td>도메인 UI, API 조회·mutation, 필요한 세션 상태</td><td>서로 무관한 도메인의 UI·화면 컴포넌트</td></tr>
+          <tr><td><code>components/ui</code></td><td>props와 범용 UI 상태</td><td>도메인 API, Zustand 스토어, 특정 라우트에 대한 직접 의존</td></tr>
+          <tr><td><code>components/common</code></td><td><code>components/ui</code>, Router 링크, 공통 asset·유틸리티</td><td>특정 도메인의 API·스토어·권한 규칙</td></tr>
+        </tbody>
+      </table>
+      <h2>함께 확인할 지원 영역</h2>
+      <ul>
+        <li><code>service/schema</code>: Zod 기반 입력 검증</li>
+        <li><code>types</code>: 역할·학기 등 앱 공통 타입</li>
+        <li><code>utils</code>, <code>constant</code>: 역할 비교, 변환, 오류 메시지</li>
+        <li><code>data</code>, <code>assets</code>: 정적 콘텐츠와 이미지·SVG</li>
+      </ul>
+      <aside class="notice"><strong>생성 코드:</strong> <code>src/service/model/</code>과 <code>src/lib/http-client.ts</code>는 Swagger 생성 파일입니다. 직접 수정하지 않고 호출부와 API 계약을 검토합니다.</aside>
+      <p class="footer"><a href="../index.html">시작으로</a> · 다음: <a href="../navigation-and-access/index.html">화면·접근</a></p>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script>mermaid.initialize({ startOnLoad: true, securityLevel: 'strict', theme: 'neutral' });</script>
+  </body>
+</html>

--- a/frontend/docs/architecture/styles.css
+++ b/frontend/docs/architecture/styles.css
@@ -1,0 +1,33 @@
+:root {
+  color: #172033;
+  background: #f6f8fb;
+  font-family: Pretendard, "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.65;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; }
+a { color: #1f5fbf; text-underline-offset: 0.18em; }
+a:hover { color: #17488e; }
+.site-header { padding: 1.5rem max(1.25rem, calc((100vw - 1120px) / 2)); background: #102a53; color: #fff; }
+.site-header a { color: #fff; text-decoration: none; }
+.brand { display: block; font-size: 1.1rem; font-weight: 800; }
+.site-nav { display: flex; flex-wrap: wrap; gap: 0.6rem 1rem; margin-top: 0.65rem; }
+.site-nav a { color: #dbeafe; font-size: 0.95rem; }
+.site-nav a[aria-current="page"] { color: #fff; font-weight: 700; }
+main { width: min(100% - 2.5rem, 980px); margin: 0 auto; padding: 3rem 0 4rem; }
+h1, h2, h3 { color: #102a53; line-height: 1.28; }
+h1 { margin: 0 0 0.85rem; font-size: clamp(2rem, 4vw, 2.8rem); }
+h2 { margin-top: 2.75rem; padding-bottom: 0.4rem; border-bottom: 1px solid #d9e1ee; }
+.lede { max-width: 65ch; color: #4a5568; font-size: 1.13rem; }
+.card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.5rem 0; }
+.card { padding: 1.25rem; border: 1px solid #d9e1ee; border-radius: 0.75rem; background: #fff; box-shadow: 0 3px 10px rgb(15 42 83 / 5%); }
+.card h2 { margin: 0 0 0.5rem; padding: 0; border: 0; font-size: 1.25rem; }
+.notice { padding: 1rem 1.15rem; border-left: 4px solid #2c74c9; border-radius: 0.25rem; background: #eef6ff; }
+table { display: block; width: 100%; max-width: 100%; overflow-x: auto; border-collapse: collapse; background: #fff; }
+th, td { padding: 0.75rem; border: 1px solid #d9e1ee; text-align: left; vertical-align: top; }
+th { color: #102a53; background: #eff4fa; }
+code { padding: 0.12rem 0.3rem; border-radius: 0.25rem; color: #173a69; background: #edf1f7; }
+.mermaid { overflow-x: auto; margin: 1.5rem 0; padding: 1rem; border: 1px solid #d9e1ee; border-radius: 0.75rem; background: #fff; text-align: center; }
+.footer { padding-top: 1rem; border-top: 1px solid #d9e1ee; color: #5d6878; font-size: 0.9rem; }
+@media (max-width: 640px) { main { width: min(100% - 1.5rem, 980px); padding-top: 2rem; } .site-header { padding: 1.25rem; } th, td { min-width: 150px; } }


### PR DESCRIPTION
### 📝 상세 내용

- Codex·Claude용 `architecture-diagram` 스킬을 추가했습니다.
  - 프로젝트의 구조와 동작 방식을 코드 기준으로 점검하고 HTML 문서 갱신
  - 개발자는 HTML문서를 브라우저로 열어 확인 가능
- `architecture-diagram` 스킬을 사용해 프로젝트 구조, 데이터·상태, 내비게이션·접근 흐름을 설명하는 문서를 추가했습니다.
- CodeRabbit 리뷰를 위한 규칙을 추가했습니다.

### #️⃣ 이슈 번호
- close #183

### 🔗 참고 자료

- 없음

### 📷 스크린샷(선택)

- 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 아키텍처 랜딩 페이지와 화면 진입·접근 제어, 데이터·상태 관리 문서가 추가되었습니다. 라우팅/역할 우선순위와 로딩·오류 경계 흐름을 Mermaid로 확인할 수 있습니다.
  * 문서용 스타일(모바일 포함)과 아키텍처 다이어그램 검증·갱신 절차가 제공됩니다.
* **개선**
  * 커밋 메시지 작성 규칙 및 아키텍처 문서 활용 안내를 정비했습니다. 또한 작업 범위를 더 명확히 안내합니다.
* **설정**
  * CodeRabbit 리뷰 자동화 설정을 한국어 환경에 맞게 조정하고 관련 자동화 기능을 비활성화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->